### PR TITLE
Extend metrics with a running tasks gauge

### DIFF
--- a/scheduler/metrics.go
+++ b/scheduler/metrics.go
@@ -1,0 +1,36 @@
+package scheduler
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	TasksCreated = prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: "scheduler",
+		Name:      "tasks_created",
+		Help:      "Number of tasks submitted to eremetic",
+	})
+	TasksLaunched = prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: "scheduler",
+		Name:      "tasks_launched",
+		Help:      "Number of tasks launched by eremetic",
+	})
+	TasksTerminated = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: "scheduler",
+		Name:      "tasks_terminated",
+		Help:      "Number of terminated tasks by terminal status",
+	}, []string{"status"})
+	TasksDelayed = prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: "scheduler",
+		Name:      "tasks_delayed",
+		Help:      "Number of times the launch of a task has been delayed",
+	})
+	TasksRunning = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: "schedelure",
+		Name:      "tasks_running",
+		Help:      "Number of tasks currently running",
+	})
+	QueueSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: "scheduler",
+		Name:      "queue_size",
+		Help:      "Number of tasks in the queue",
+	})
+)

--- a/types/task.go
+++ b/types/task.go
@@ -41,6 +41,14 @@ func (task *EremeticTask) IsTerminated() bool {
 	return IsTerminalString(st.Status)
 }
 
+func (task *EremeticTask) IsRunning() bool {
+	if len(task.Status) == 0 {
+		return false
+	}
+	st := task.Status[len(task.Status)-1]
+	return st.Status == mesos.TaskState_TASK_RUNNING.String()
+}
+
 func (task *EremeticTask) LastUpdated() time.Time {
 	if len(task.Status) == 0 {
 		return time.Unix(0, 0)

--- a/types/task_test.go
+++ b/types/task_test.go
@@ -85,6 +85,31 @@ func TestTask(t *testing.T) {
 		})
 	})
 
+	Convey("IsRunning", t, func() {
+		Convey("A task that was running", func() {
+			task := EremeticTask{
+				Status: []Status{
+					Status{0, "TASK_STAGING"},
+					Status{1, "TASK_RUNNING"},
+					Status{2, "TASK_FINISHED"},
+				},
+			}
+
+			So(task.IsRunning(), ShouldBeFalse)
+		})
+
+		Convey("A task that is running", func() {
+			task := EremeticTask{
+				Status: []Status{
+					Status{0, "TASK_STAGING"},
+					Status{1, "TASK_RUNNING"},
+				},
+			}
+
+			So(task.IsRunning(), ShouldBeTrue)
+		})
+	})
+
 	Convey("LastUpdated", t, func() {
 		Convey("A task that is running", func() {
 			task := EremeticTask{


### PR DESCRIPTION
When doing reconciliation after a restart the difference between
launched_tasks and terminated_tasks is not guaranteed to yield the
currently running tasks. This new gauge will account for running tasks
that were recovered.