### PR TITLE
Add support for Masked Environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ JSON format:
   "env": {
     "KEY": "value"
   },
+  // Object, Will be merged to `env` when passed to Mesos, but masked when doing a GET.
+  // See Clarification of the Masked Env field below for more information
+  "masked_env": {
+    "KEY": "value"
+  },
   // URIs of resource to download
   "uris": [
     "http://server.local/resource"
@@ -49,6 +54,13 @@ JSON format:
 
 ### Note
 Most of this meta-data will not remain after a full restart of Eremetic.
+
+### Clarification of the Masked Env field
+The purpose of the field is to provide a way to pass along environment variables that you don't want to have exposed in a subsequent GET call.
+It is not intended to provide full security, as someone with access to either the machine running Eremetic or the Mesos Slave that the task is being run on will still be able to view these values.
+These values are not encrypted, but simply masked when retrieved back via the API.
+
+For security purposes, ensure TLS (https) is being used for the Eremetic communication and that access to any machines is properly restricted.
 
 
 ## Configuration

--- a/database/task.go
+++ b/database/task.go
@@ -3,8 +3,8 @@ package database
 import (
 	"encoding/json"
 
-	"github.com/klarna/eremetic/types"
 	"github.com/boltdb/bolt"
+	"github.com/klarna/eremetic/types"
 )
 
 // PutTask stores a requested task in the database
@@ -29,8 +29,24 @@ func PutTask(task *types.EremeticTask) error {
 	})
 }
 
-// ReadTask fetches a task from the database
+// ReadTask fetches a task from the database and applies a mask to the
+// MaskedEnvironment field
 func ReadTask(id string) (types.EremeticTask, error) {
+	task, err := ReadUnmaskedTask(id)
+
+	for k := range task.MaskedEnvironment {
+		task.MaskedEnvironment[k] = "*******"
+	}
+
+	return task, err
+}
+
+// ReadUnmaskedTask fetches a task from the database and does not mask the
+// MaskedEnvironment field.
+// This function should be considered internal to Eremetic, and is used where
+// we need to fetch a task and then re-save it to the database. It should not
+// be returned to the API.
+func ReadUnmaskedTask(id string) (types.EremeticTask, error) {
 	var task types.EremeticTask
 
 	err := ensureDB()
@@ -51,6 +67,8 @@ func ReadTask(id string) (types.EremeticTask, error) {
 	return task, err
 }
 
+// ListNonTerminalTasks returns a list of tasks that are not yet finished in one
+// way or another.
 func ListNonTerminalTasks() ([]*types.EremeticTask, error) {
 	var tasks []*types.EremeticTask
 

--- a/misc/swagger.yaml
+++ b/misc/swagger.yaml
@@ -95,6 +95,9 @@ definitions:
       env:
         type: object
         description: Environment variables to set
+      masked_env:
+        type: object
+        description: Environment variables to set but that are masked in any GET request.
       uris:
         type: array
         items:
@@ -135,6 +138,6 @@ definitions:
                 - TASK_FAILED
                 - TASK_LOST
                 - TASK_ERROR
-            time: 
+            time:
               type: number
               description: Unix timestamp of status change

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -100,7 +100,7 @@ loop:
 			break loop
 		case tid := <-s.tasks:
 			logrus.WithField("task_id", tid).Debug("Trying to find offer to launch task with")
-			t, _ := database.ReadTask(tid)
+			t, _ := database.ReadUnmaskedTask(tid)
 			offer, offers = matchOffer(t, offers)
 
 			if offer == nil {
@@ -142,7 +142,7 @@ func (s *eremeticScheduler) StatusUpdate(driver sched.SchedulerDriver, status *m
 		"status":  status.State.String(),
 	}).Debug("Received task status update")
 
-	task, err := database.ReadTask(id)
+	task, err := database.ReadUnmaskedTask(id)
 	if err != nil {
 		logrus.WithError(err).WithField("task_id", id).Debug("Unable to read task from database")
 	}

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -38,6 +38,12 @@ func createTaskInfo(task types.EremeticTask, offer *mesos.Offer) (types.Eremetic
 			Value: proto.String(v),
 		})
 	}
+	for k, v := range task.MaskedEnvironment {
+		environment = append(environment, &mesos.Environment_Variable{
+			Name:  proto.String(k),
+			Value: proto.String(v),
+		})
+	}
 
 	environment = append(environment, &mesos.Environment_Variable{
 		Name:  proto.String("MESOS_TASK_ID"),

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -60,6 +60,18 @@ func TestTask(t *testing.T) {
 			So(task.Volumes[0].HostPath, ShouldEqual, volumes[0].HostPath)
 		})
 
+		Convey("Given a masked environment", func() {
+			var maskedEnv = make(map[string]string)
+			maskedEnv["foo"] = "bar"
+
+			request.MaskedEnvironment = maskedEnv
+			task, err := createEremeticTask(request)
+
+			So(err, ShouldBeNil)
+			So(task.MaskedEnvironment, ShouldContainKey, "foo")
+			So(task.MaskedEnvironment["foo"], ShouldEqual, "bar")
+		})
+
 		Convey("Given uri to download", func() {
 			request.URIs = []string{"http://foobar.local/kitten.jpg"}
 

--- a/types/request.go
+++ b/types/request.go
@@ -9,13 +9,14 @@ type Volume struct {
 
 // Request represents the structure of a job request
 type Request struct {
-	TaskCPUs    float64           `json:"task_cpus"`
-	TaskMem     float64           `json:"task_mem"`
-	DockerImage string            `json:"docker_image"`
-	Command     string            `json:"command"`
-	Name        string            `json:"-"`
-	Volumes     []Volume          `json:"volumes"`
-	Environment map[string]string `json:"env"`
-	CallbackURI string            `json:"callback_uri"`
-	URIs        []string          `json:"uris"`
+	TaskCPUs          float64           `json:"task_cpus"`
+	TaskMem           float64           `json:"task_mem"`
+	DockerImage       string            `json:"docker_image"`
+	Command           string            `json:"command"`
+	Name              string            `json:"-"`
+	Volumes           []Volume          `json:"volumes"`
+	Environment       map[string]string `json:"env"`
+	MaskedEnvironment map[string]string `json:"masked_env"`
+	CallbackURI       string            `json:"callback_uri"`
+	URIs              []string          `json:"uris"`
 }

--- a/types/task.go
+++ b/types/task.go
@@ -14,22 +14,23 @@ type Status struct {
 }
 
 type EremeticTask struct {
-	TaskCPUs    float64           `json:"task_cpus"`
-	TaskMem     float64           `json:"task_mem"`
-	Command     string            `json:"command"`
-	User        string            `json:"user"`
-	Environment map[string]string `json:"env"`
-	Image       string            `json:"image"`
-	Volumes     []Volume          `json:"volumes"`
-	Status      []Status          `json:"status"`
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	FrameworkId string            `json:"framework_id"`
-	SlaveId     string            `json:"slave_id"`
-	Hostname    string            `json:"hostname"`
-	Retry       int               `json:"retry"`
-	CallbackURI string            `json:"callback_uri"`
-	URIs        []string          `json:"uris"`
+	TaskCPUs          float64           `json:"task_cpus"`
+	TaskMem           float64           `json:"task_mem"`
+	Command           string            `json:"command"`
+	User              string            `json:"user"`
+	Environment       map[string]string `json:"env"`
+	MaskedEnvironment map[string]string `json:"masked_env"`
+	Image             string            `json:"image"`
+	Volumes           []Volume          `json:"volumes"`
+	Status            []Status          `json:"status"`
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	FrameworkId       string            `json:"framework_id"`
+	SlaveId           string            `json:"slave_id"`
+	Hostname          string            `json:"hostname"`
+	Retry             int               `json:"retry"`
+	CallbackURI       string            `json:"callback_uri"`
+	URIs              []string          `json:"uris"`
 }
 
 func NewEremeticTask(request Request) (EremeticTask, error) {
@@ -48,18 +49,19 @@ func NewEremeticTask(request Request) (EremeticTask, error) {
 	}
 
 	task := EremeticTask{
-		ID:          taskID,
-		TaskCPUs:    request.TaskCPUs,
-		TaskMem:     request.TaskMem,
-		Name:        request.Name,
-		Status:      status,
-		Command:     request.Command,
-		User:        "root",
-		Environment: request.Environment,
-		Image:       request.DockerImage,
-		Volumes:     request.Volumes,
-		CallbackURI: request.CallbackURI,
-		URIs:        request.URIs,
+		ID:                taskID,
+		TaskCPUs:          request.TaskCPUs,
+		TaskMem:           request.TaskMem,
+		Name:              request.Name,
+		Status:            status,
+		Command:           request.Command,
+		User:              "root",
+		Environment:       request.Environment,
+		MaskedEnvironment: request.MaskedEnvironment,
+		Image:             request.DockerImage,
+		Volumes:           request.Volumes,
+		CallbackURI:       request.CallbackURI,
+		URIs:              request.URIs,
 	}
 	return task, nil
 }


### PR DESCRIPTION
The purpose of these is to be able to pass in for example credentials to
your docker container at runtime, but not have them exposed through a
GET with the Eremetic API.

They are not encrypted, and will still be viewable if someone has access
to the machine running the task, as they are merged to the env field
before being passed to Mesos.

See the readme for more information, and follow best practices for
secure communication for REST-ful APIs.