### PR TITLE
Add optional task constraints on mesos slave attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,13 @@ docker-clean: docker/Dockerfile docker/marathon.sh
 	$(DOCKER_GOLANG_RUN_CMD) "make docker/eremetic"
 	docker build -t ${DOCKERTAG} docker
 
-publish-docker: docker
+publish-docker:
+ifeq ($(strip $(shell docker images --format "{{.Repository}}:{{.Tag}}" $(DOCKERTAG))),)
+	$(warning Docker tag does not exist:)
+	$(warning ${DOCKERTAG})
+	$(warning )
+	$(error Cannot publish the docker image. Please run `make docker` or `make docker-clean` first.)
+endif
 	docker push ${DOCKERTAG}
 	git describe HEAD --exact 2>/dev/null && \
 		docker tag ${DOCKERTAG} ${DOCKERNAME}:latest && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test docker publish-docker
+.PHONY: all test test-server test-docker docker docker-clean publish-docker 
 
 VERSION?=$(shell git describe HEAD | sed s/^v//)
 DATE?=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
@@ -10,6 +10,9 @@ TOOLS=${GOPATH}/bin/go-bindata \
 	  ${GOPATH}/bin/goconvey
 SRC=$(shell find . -name '*.go')
 STATIC=$(shell find static templates)
+
+DOCKER_GO_SRC_PATH=/go/src/github.com/klarna/eremetic
+DOCKER_GOLANG_RUN_CMD=docker run --rm -v "$(PWD)":$(DOCKER_GO_SRC_PATH) -w $(DOCKER_GO_SRC_PATH) golang:1.6 bash -c
 
 all: test
 
@@ -23,6 +26,10 @@ test: eremetic
 
 test-server: ${TOOLS} 
 	${GOPATH}/bin/goconvey
+
+# Run tests cleanly in a docker container.
+test-docker:
+	$(DOCKER_GOLANG_RUN_CMD) "make test"
 
 assets/assets.go: generate.go ${STATIC}
 	go generate
@@ -38,6 +45,12 @@ docker/eremetic: ${SRC}
 	CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -a -installsuffix cgo -o $@
 
 docker: docker/eremetic docker/Dockerfile docker/marathon.sh
+	docker build -t ${DOCKERTAG} docker
+
+docker-clean: docker/Dockerfile docker/marathon.sh
+	# Create the docker/eremetic binary in the Docker container using the
+	# golang docker image. This ensures a completely clean build.
+	$(DOCKER_GOLANG_RUN_CMD) "make docker/eremetic"
 	docker build -t ${DOCKERTAG} docker
 
 publish-docker: docker

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ DOCKERNAME?=alde/eremetic
 DOCKERTAG?=${DOCKERNAME}:${VERSION}
 LDFLAGS=-X main.Version '${VERSION}' -X main.BuildDate '${DATE}'
 TOOLS=${GOPATH}/bin/go-bindata \
-      ${GOPATH}/bin/go-bindata-assetfs
+      ${GOPATH}/bin/go-bindata-assetfs \
+	  ${GOPATH}/bin/goconvey
 SRC=$(shell find . -name '*.go')
 STATIC=$(shell find static templates)
 
@@ -15,9 +16,13 @@ all: test
 ${TOOLS}:
 	go get github.com/jteeuwen/go-bindata/...
 	go get github.com/elazarl/go-bindata-assetfs/...
+	go get github.com/smartystreets/goconvey
 
 test: eremetic
 	go test -v ./...
+
+test-server: ${TOOLS} 
+	${GOPATH}/bin/goconvey
 
 assets/assets.go: generate.go ${STATIC}
 	go generate

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ JSON format:
   "uris": [
     "http://server.local/resource"
   ],
-  // Constraints for which slave the task can run on (beyond cpu/memory). Currently supported: attributes
-  // If multiple constraints exist, they are evaluated using AND (ie: all or none).
+  // Constraints for which slave the task can run on (beyond cpu/memory).
+  // Matching is strict and only attributes are currently supported. If
+  // multiple constraints exist, they are evaluated using AND (ie: all or none).
   "slave_constraints": [       
       {
           "attribute_name": "aws-region",

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ JSON format:
   "uris": [
     "http://server.local/resource"
   ],
+  // Constraints for which slave the task can run on (beyond cpu/memory). Currently supported: attributes
+  // If multiple constraints exist, they are evaluated using AND (ie: all or none).
+  "slave_constraints": [       
+      {
+          "attribute_name": "aws-region",
+          "attribute_value": "us-west-2"
+      }
+  ],
   // String, URL to post a callback to. Callback message has format:
   // {"time":1451398320,"status":"TASK_FAILED","task_id":"eremetic-task.79feb50d-3d36-47cf-98ff-a52ef2bc0eb5"}
   "callback_uri": "http://callback.local"

--- a/examples.md
+++ b/examples.md
@@ -80,7 +80,7 @@ the time on any Mesos Slave with the attribute "role" set to "build".
 ```json
 {
     "docker_image": "busybox",
-    "command": "for i in $(seq 1 5); do echo \"`date` $i\"; done",
+    "command": "for i in $(seq 1 5); do echo \"`date` $i\"; sleep 5; done",
     "task_cpus": 0.1,
     "task_mem": 100.0,
     "slave_constraints": [

--- a/examples.md
+++ b/examples.md
@@ -71,3 +71,27 @@ arbitrary dockerfiles by url.
     ]
 }
 ```
+
+## Running a task with certain attributes
+
+This configures a task to run the `busybox` image with a basic loop outputting
+the time on any Mesos Slave with the attribute "role" set to "build".
+
+```json
+{
+    "docker_image": "busybox",
+    "command": "for i in $(seq 1 5); do echo \"`date` $i\"; done",
+    "task_cpus": 0.1,
+    "task_mem": 100.0,
+    "slave_constraints": [
+        { 
+            "attribute_name": "role",
+            "attribute_value": "build"
+        }
+    ]
+}
+```
+
+Mesos slaves can be configured with arbitrary attributes. See the
+[documentation](https://open.mesosphere.com/reference/mesos-slave/) for more
+information on how to configure attributes.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -171,6 +171,7 @@ func makeMap(task types.EremeticTask) map[string]interface{} {
 	data["Hostname"] = task.Hostname
 	data["Name"] = task.Name
 	data["SlaveID"] = task.SlaveId
+	data["SlaveConstraints"] = task.SlaveConstraints
 	data["Status"] = task.Status
 	data["CPU"] = fmt.Sprintf("%.2f", task.TaskCPUs)
 	data["Memory"] = fmt.Sprintf("%.2f", task.TaskMem)

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRoutes(t *testing.T) {
-	routes := []string{"AddTask", "Status"}
+	routes := []string{"AddTask", "Status", "ListRunningTasks"}
 
 	Convey("Create", t, func() {
 		Convey("Should build the expected routes", func() {

--- a/scheduler/match.go
+++ b/scheduler/match.go
@@ -16,7 +16,7 @@ type resourceMatcher struct {
 }
 
 type attributeMatcher struct {
-	SlaveConstraints []types.SlaveConstraint
+	SlaveConstraints []*types.SlaveConstraint
 }
 
 func (m *resourceMatcher) Matches(o interface{}) error {
@@ -89,7 +89,7 @@ func (m *attributeMatcher) Description() string {
 	return description
 }
 
-func AttributeMatch(slaveConstraints []types.SlaveConstraint) ogle.Matcher {
+func AttributeMatch(slaveConstraints []*types.SlaveConstraint) ogle.Matcher {
 	logrus.Info("AttributeAvailable()")
 	return &attributeMatcher{slaveConstraints}
 }
@@ -98,7 +98,7 @@ func createMatcher(task types.EremeticTask) ogle.Matcher {
 	return ogle.AllOf(
 		CPUAvailable(task.TaskCPUs),
 		MemoryAvailable(task.TaskMem),
-		AttributeMatch(task.SlaveConstraints),
+		//AttributeMatch(task.SlaveConstraints),
 	)
 }
 

--- a/scheduler/match.go
+++ b/scheduler/match.go
@@ -61,20 +61,27 @@ func (m *attributeMatcher) Matches(o interface{}) (err error) {
 				logrus.WithFields(logrus.Fields{
 					"attr.GetName()":            attr.GetName(),
 					"attr.Text.GetValue()":      attr.Text.GetValue(),
+					"attr.GetType()":            attr.GetType(),
+					"mesos.Value_TEXT":          mesos.Value_TEXT,
 					"constraint.AttributeName":  constraint.AttributeName,
 					"constraint.AttributeValue": constraint.AttributeValue,
 				}).Info("attributeMatcher found matching constraint")
 
-				if attr.GetType() != mesos.Value_TEXT ||
-					attr.Text.GetValue() == constraint.AttributeValue {
+				if attr.GetType() != mesos.Value_TEXT {
 					err = errors.New("")
+					return
+				}
+
+				if attr.Text.GetValue() != constraint.AttributeValue {
+					err = errors.New("")
+					return
 				}
 
 				return
 			}
 		}
 	}
-	return err
+	return
 }
 
 func (m *attributeMatcher) Description() string {

--- a/scheduler/match.go
+++ b/scheduler/match.go
@@ -15,6 +15,10 @@ type resourceMatcher struct {
 	value float64
 }
 
+type attributeMatcher struct {
+	SlaveConstraints []types.SlaveConstraint
+}
+
 func (m *resourceMatcher) Matches(o interface{}) error {
 	offer := o.(*mesos.Offer)
 	err := errors.New("")
@@ -47,10 +51,55 @@ func MemoryAvailable(v float64) ogle.Matcher {
 	return &resourceMatcher{"mem", v}
 }
 
+func (m *attributeMatcher) Matches(o interface{}) error {
+	offer := o.(*mesos.Offer)
+	err := errors.New("")
+
+	for _, constraint := range m.SlaveConstraints {
+		for _, attr := range offer.Attributes {
+			if attr.GetName() == constraint.AttributeName {
+
+				logrus.WithFields(logrus.Fields{
+					"attr.GetName()":            attr.GetName(),
+					"attr.Text.GetValue()":      attr.Text.GetValue(),
+					"constraint.AttributeName":  constraint.AttributeName,
+					"constraint.AttributeValue": constraint.AttributeValue,
+				}).Info("attributeMatcher found matching constraint")
+
+				if attr.GetType() != mesos.Value_TEXT {
+					return err
+				}
+
+				if attr.Text.GetValue() == constraint.AttributeValue {
+					return nil
+				}
+
+				return err
+			}
+		}
+	}
+	return err
+}
+
+func (m *attributeMatcher) Description() string {
+	description := ""
+	for _, constraint := range m.SlaveConstraints {
+		description += fmt.Sprintf("%s of attribute %s, ", constraint.AttributeValue, constraint.AttributeName)
+	}
+	return description
+}
+
+func AttributeMatch(slaveConstraints []types.SlaveConstraint) ogle.Matcher {
+	logrus.Info("AttributeAvailable()")
+	return &attributeMatcher{slaveConstraints}
+}
+
 func createMatcher(task types.EremeticTask) ogle.Matcher {
 	return ogle.AllOf(
 		CPUAvailable(task.TaskCPUs),
-		MemoryAvailable(task.TaskMem))
+		MemoryAvailable(task.TaskMem),
+		AttributeMatch(task.SlaveConstraints),
+	)
 }
 
 func matches(matcher ogle.Matcher, o interface{}) bool {

--- a/scheduler/match_test.go
+++ b/scheduler/match_test.go
@@ -50,6 +50,7 @@ func TestMatch(t *testing.T) {
 	)
 	offerB := offer("offer-b", 1.8, 512.0, &mesos.Attribute{
 		Name: proto.String("node_name"),
+		Type: mesos.Value_TEXT.Enum(),
 		Text: &mesos.Value_Text{
 			Value: proto.String("node2"),
 		},
@@ -83,28 +84,28 @@ func TestMatch(t *testing.T) {
 		})
 	})
 
-	//Convey("AttributeMatch", t, func() {
-	//Convey("Does match", func() {
-	//m := AttributeMatch([]*types.SlaveConstraint{
-	//types.SlaveConstraint{
-	//AttributeName:  "node_name",
-	//AttributeValue: "node1",
-	//},
-	//})
-	//err := m.Matches(offerA)
-	//So(err, ShouldBeNil)
-	//})
-	//Convey("Does not match", func() {
-	//m := AttributeMatch([]*types.SlaveConstraint{
-	//types.SlaveConstraint{
-	//AttributeName:  "node_name",
-	//AttributeValue: "node2",
-	//},
-	//})
-	//err := m.Matches(offerA)
-	//So(err, ShouldNotBeNil)
-	//})
-	//})
+	Convey("AttributeMatch", t, func() {
+		Convey("Does match", func() {
+			m := AttributeMatch([]types.SlaveConstraint{
+				types.SlaveConstraint{
+					AttributeName:  "node_name",
+					AttributeValue: "node1",
+				},
+			})
+			err := m.Matches(offerA)
+			So(err, ShouldBeNil)
+		})
+		Convey("Does not match", func() {
+			m := AttributeMatch([]types.SlaveConstraint{
+				types.SlaveConstraint{
+					AttributeName:  "node_name",
+					AttributeValue: "node2",
+				},
+			})
+			err := m.Matches(offerA)
+			So(err, ShouldNotBeNil)
+		})
+	})
 
 	Convey("matchOffer", t, func() {
 		Convey("Tasks without SlaveConstraints", func() {

--- a/scheduler/match_test.go
+++ b/scheduler/match_test.go
@@ -83,28 +83,28 @@ func TestMatch(t *testing.T) {
 		})
 	})
 
-	Convey("AttributeMatch", t, func() {
-		Convey("Does match", func() {
-			m := AttributeMatch([]types.SlaveConstraint{
-				types.SlaveConstraint{
-					AttributeName:  "node_name",
-					AttributeValue: "node1",
-				},
-			})
-			err := m.Matches(offerA)
-			So(err, ShouldBeNil)
-		})
-		Convey("Does not match", func() {
-			m := AttributeMatch([]types.SlaveConstraint{
-				types.SlaveConstraint{
-					AttributeName:  "node_name",
-					AttributeValue: "node2",
-				},
-			})
-			err := m.Matches(offerA)
-			So(err, ShouldNotBeNil)
-		})
-	})
+	//Convey("AttributeMatch", t, func() {
+	//Convey("Does match", func() {
+	//m := AttributeMatch([]*types.SlaveConstraint{
+	//types.SlaveConstraint{
+	//AttributeName:  "node_name",
+	//AttributeValue: "node1",
+	//},
+	//})
+	//err := m.Matches(offerA)
+	//So(err, ShouldBeNil)
+	//})
+	//Convey("Does not match", func() {
+	//m := AttributeMatch([]*types.SlaveConstraint{
+	//types.SlaveConstraint{
+	//AttributeName:  "node_name",
+	//AttributeValue: "node2",
+	//},
+	//})
+	//err := m.Matches(offerA)
+	//So(err, ShouldNotBeNil)
+	//})
+	//})
 
 	Convey("matchOffer", t, func() {
 		Convey("Tasks without SlaveConstraints", func() {

--- a/scheduler/match_test.go
+++ b/scheduler/match_test.go
@@ -23,6 +23,11 @@ func offer(id string, cpu float64, mem float64, attributes ...*mesos.Attribute) 
 			Value: proto.String("slave-1234"),
 		},
 		Hostname: proto.String("localhost"),
+		Url: &mesos.URL{
+			Address: &mesos.Address{
+				Port: proto.Int32(5050),
+			},
+		},
 		Resources: []*mesos.Resource{
 			mesosutil.NewScalarResource("cpus", cpu),
 			mesosutil.NewScalarResource("mem", mem),

--- a/scheduler/match_test.go
+++ b/scheduler/match_test.go
@@ -34,10 +34,10 @@ func offer(id string, cpu float64, mem float64, attributes ...*mesos.Attribute) 
 func TestMatch(t *testing.T) {
 	offerA := offer("offer-a", 0.6, 200.0,
 		&mesos.Attribute{
-			Name: proto.String("node_name"),
+			Name: proto.String("role"),
 			Type: mesos.Value_TEXT.Enum(),
 			Text: &mesos.Value_Text{
-				Value: proto.String("node1"),
+				Value: proto.String("badassmofo"),
 			},
 		},
 		&mesos.Attribute{
@@ -48,13 +48,15 @@ func TestMatch(t *testing.T) {
 			},
 		},
 	)
-	offerB := offer("offer-b", 1.8, 512.0, &mesos.Attribute{
-		Name: proto.String("node_name"),
-		Type: mesos.Value_TEXT.Enum(),
-		Text: &mesos.Value_Text{
-			Value: proto.String("node2"),
+	offerB := offer("offer-b", 1.8, 512.0,
+		&mesos.Attribute{
+			Name: proto.String("node_name"),
+			Type: mesos.Value_TEXT.Enum(),
+			Text: &mesos.Value_Text{
+				Value: proto.String("node2"),
+			},
 		},
-	})
+	)
 
 	Convey("CPUAvailable", t, func() {
 		Convey("Above", func() {
@@ -72,6 +74,7 @@ func TestMatch(t *testing.T) {
 
 	Convey("MemoryAvailable", t, func() {
 		Convey("Above", func() {
+
 			m := MemoryAvailable(128.0)
 			err := m.Matches(offerA)
 			So(err, ShouldBeNil)
@@ -162,6 +165,58 @@ func TestMatch(t *testing.T) {
 				So(offer, ShouldEqual, offerB)
 				So(others, ShouldHaveLength, 1)
 				So(others, ShouldContain, offerA)
+			})
+
+			Convey("No matching slave with attribute", func() {
+				// Use task/mem constraints which match both offers.
+				task := types.EremeticTask{
+					TaskCPUs: 0.5,
+					TaskMem:  128.0,
+					SlaveConstraints: []types.SlaveConstraint{
+						types.SlaveConstraint{
+							AttributeName:  "node_name",
+							AttributeValue: "sherah",
+						},
+					},
+				}
+				offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
+
+				So(offer, ShouldBeNil)
+				So(others, ShouldHaveLength, 2)
+			})
+
+			Convey("Match slave with mulitple attributes", func() {
+				// Build two new offers, both with the same role as offerA.
+				offerC := offer("offer-c", 0.6, 200.0,
+					&mesos.Attribute{Name: proto.String("role"), Type: mesos.Value_TEXT.Enum(), Text: &mesos.Value_Text{Value: proto.String("badassmofo")}},
+					&mesos.Attribute{Name: proto.String("node_name"), Type: mesos.Value_TEXT.Enum(), Text: &mesos.Value_Text{Value: proto.String("node3")}},
+				)
+				offerD := offer("offer-d", 0.6, 200.0,
+					&mesos.Attribute{Name: proto.String("role"), Type: mesos.Value_TEXT.Enum(), Text: &mesos.Value_Text{Value: proto.String("badassmofo")}},
+				)
+
+				task := types.EremeticTask{
+					TaskCPUs: 0.5,
+					TaskMem:  128.0,
+					SlaveConstraints: []types.SlaveConstraint{
+						types.SlaveConstraint{
+							AttributeName:  "role",
+							AttributeValue: "badassmofo",
+						},
+						types.SlaveConstraint{
+							AttributeName:  "node_name",
+							AttributeValue: "node3",
+						},
+					},
+				}
+				// Specifically add C last, our expected, so that we ensure
+				// the other mocks do not match first.
+				offer, others := matchOffer(task, []*mesos.Offer{offerA, offerD, offerC})
+
+				So(offer, ShouldEqual, offerC)
+				So(others, ShouldHaveLength, 2)
+				So(others, ShouldContain, offerA)
+				So(others, ShouldContain, offerD)
 			})
 		})
 	})

--- a/scheduler/match_test.go
+++ b/scheduler/match_test.go
@@ -10,7 +10,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func offer(id string, cpu float64, mem float64) *mesos.Offer {
+// Optional attributes can be added.
+func offer(id string, cpu float64, mem float64, attributes ...*mesos.Attribute) *mesos.Offer {
 	return &mesos.Offer{
 		Id: &mesos.OfferID{
 			Value: proto.String(id),
@@ -26,12 +27,33 @@ func offer(id string, cpu float64, mem float64) *mesos.Offer {
 			mesosutil.NewScalarResource("cpus", cpu),
 			mesosutil.NewScalarResource("mem", mem),
 		},
+		Attributes: attributes,
 	}
 }
 
 func TestMatch(t *testing.T) {
-	offerA := offer("offer-a", 0.6, 200.0)
-	offerB := offer("offer-b", 1.8, 512.0)
+	offerA := offer("offer-a", 0.6, 200.0,
+		&mesos.Attribute{
+			Name: proto.String("node_name"),
+			Type: mesos.Value_TEXT.Enum(),
+			Text: &mesos.Value_Text{
+				Value: proto.String("node1"),
+			},
+		},
+		&mesos.Attribute{
+			Name: proto.String("node_name"),
+			Type: mesos.Value_TEXT.Enum(),
+			Text: &mesos.Value_Text{
+				Value: proto.String("node1"),
+			},
+		},
+	)
+	offerB := offer("offer-b", 1.8, 512.0, &mesos.Attribute{
+		Name: proto.String("node_name"),
+		Text: &mesos.Value_Text{
+			Value: proto.String("node2"),
+		},
+	})
 
 	Convey("CPUAvailable", t, func() {
 		Convey("Above", func() {
@@ -61,39 +83,85 @@ func TestMatch(t *testing.T) {
 		})
 	})
 
+	Convey("AttributeMatch", t, func() {
+		Convey("Does match", func() {
+			m := AttributeMatch([]types.SlaveConstraint{
+				types.SlaveConstraint{
+					AttributeName:  "node_name",
+					AttributeValue: "node1",
+				},
+			})
+			err := m.Matches(offerA)
+			So(err, ShouldBeNil)
+		})
+		Convey("Does not match", func() {
+			m := AttributeMatch([]types.SlaveConstraint{
+				types.SlaveConstraint{
+					AttributeName:  "node_name",
+					AttributeValue: "node2",
+				},
+			})
+			err := m.Matches(offerA)
+			So(err, ShouldNotBeNil)
+		})
+	})
+
 	Convey("matchOffer", t, func() {
-		Convey("Match", func() {
-			task := types.EremeticTask{
-				TaskCPUs: 0.8,
-				TaskMem:  128.0,
-			}
-			offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
+		Convey("Tasks without SlaveConstraints", func() {
+			Convey("Match", func() {
+				task := types.EremeticTask{
+					TaskCPUs: 0.8,
+					TaskMem:  128.0,
+				}
+				offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
 
-			So(offer, ShouldEqual, offerB)
-			So(others, ShouldHaveLength, 1)
-			So(others, ShouldContain, offerA)
+				So(offer, ShouldEqual, offerB)
+				So(others, ShouldHaveLength, 1)
+				So(others, ShouldContain, offerA)
+			})
+
+			Convey("No match CPU", func() {
+				task := types.EremeticTask{
+					TaskCPUs: 2.0,
+					TaskMem:  128.0,
+				}
+				offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
+
+				So(offer, ShouldBeNil)
+				So(others, ShouldHaveLength, 2)
+			})
+
+			Convey("No match MEM", func() {
+				task := types.EremeticTask{
+					TaskCPUs: 0.2,
+					TaskMem:  712.0,
+				}
+				offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
+
+				So(offer, ShouldBeNil)
+				So(others, ShouldHaveLength, 2)
+			})
 		})
 
-		Convey("No match CPU", func() {
-			task := types.EremeticTask{
-				TaskCPUs: 2.0,
-				TaskMem:  128.0,
-			}
-			offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
+		Convey("Tasks with SlaveConstraints", func() {
+			Convey("Match slave with attribute", func() {
+				// Use task/mem constraints which match both offers.
+				task := types.EremeticTask{
+					TaskCPUs: 0.5,
+					TaskMem:  128.0,
+					SlaveConstraints: []types.SlaveConstraint{
+						types.SlaveConstraint{
+							AttributeName:  "node_name",
+							AttributeValue: "node2",
+						},
+					},
+				}
+				offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
 
-			So(offer, ShouldBeNil)
-			So(others, ShouldHaveLength, 2)
-		})
-
-		Convey("No match MEM", func() {
-			task := types.EremeticTask{
-				TaskCPUs: 0.2,
-				TaskMem:  712.0,
-			}
-			offer, others := matchOffer(task, []*mesos.Offer{offerA, offerB})
-
-			So(offer, ShouldBeNil)
-			So(others, ShouldHaveLength, 2)
+				So(offer, ShouldEqual, offerB)
+				So(others, ShouldHaveLength, 1)
+				So(others, ShouldContain, offerA)
+			})
 		})
 	})
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -268,8 +268,9 @@ func nextID(s *eremeticScheduler) int {
 
 func (s *eremeticScheduler) ScheduleTask(request types.Request) (string, error) {
 	logrus.WithFields(logrus.Fields{
-		"docker_image": request.DockerImage,
-		"command":      request.Command,
+		"docker_image":      request.DockerImage,
+		"command":           request.Command,
+		"slave_constraints": request.SlaveConstraints,
 	}).Debug("Adding task to queue")
 
 	request.Name = fmt.Sprintf("Eremetic task %d", nextID(s))

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -64,6 +64,11 @@ func TestScheduler(t *testing.T) {
 					Value: proto.String("slave-id"),
 				},
 				Hostname: proto.String("hostname"),
+				Url: &mesos.URL{
+					Address: &mesos.Address{
+						Port: proto.Int32(5050),
+					},
+				},
 			}
 			taskData, mesosTask := s.newTask(task, &offer)
 

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -30,6 +30,7 @@ func createTaskInfo(task types.EremeticTask, offer *mesos.Offer) (types.Eremetic
 	task.FrameworkId = *offer.FrameworkId.Value
 	task.SlaveId = *offer.SlaveId.Value
 	task.Hostname = *offer.Hostname
+	task.Port = *offer.Url.Address.Port
 
 	var environment []*mesos.Environment_Variable
 	for k, v := range task.Environment {

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -111,6 +111,11 @@ func TestTask(t *testing.T) {
 				Value: proto.String("slave-id"),
 			},
 			Hostname: proto.String("hostname"),
+			Url: &mesos.URL{
+				Address: &mesos.Address{
+					Port: proto.Int32(5050),
+				},
+			},
 		}
 
 		Convey("No volume or environment specified", func() {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -123,8 +123,10 @@
 .ui.button.eremetic_teal {
   background-color: #0199c8;
 }
-.volumes .two.fields .field input,
-.env .two.fields .field input {
+.volumes .field input,
+.env .field input,
+.uri .field input,
+.slave_constraints .field input {
   width: auto !important;
 }
 

--- a/static/js/eremetic.js
+++ b/static/js/eremetic.js
@@ -27,6 +27,13 @@ $(document).ready(function() {
       }, {});
     }
 
+    if (typeof json.slave_constraints !== "undefined") {
+      json.slave_constraints = json.slave_constraints.reduce(function(collector, element) {
+        collector.push({ 'attribute_name': element.attribute_name, 'attribute_value': element.attribute_value });
+        return collector;
+      }, []);
+    }
+
     json.task_cpus = parseFloat(json.task_cpus);
     json.task_mem = parseFloat(json.task_mem);
 
@@ -78,6 +85,17 @@ $(document).ready(function() {
         two: {
           name: 'env['+number+'][value]',
           placeholder: 'value'
+        }
+      }
+    } else if (type === 'slave_constraints') {
+      input = {
+        one: {
+          name: 'slave_constraints['+number+'][attribute_name]',
+          placeholder: 'Attribute Name'
+        },
+        two: {
+          name: 'slave_constraints['+number+'][attribute_value]',
+          placeholder: 'Attribute Value'
         }
       }
     } else if (type === 'volumes') {
@@ -150,7 +168,7 @@ $(document).ready(function() {
         '<div class="field">' +
           '<input name="uri_' + index + '" placeholder="URI"/>' +
         '</div>' +
-        '<button class="ui icon button">' +
+        '&nbsp;<button class="ui icon button">' +
           '<i class="minus red icon"></i>' +
         '</button>' +
       '</div>'
@@ -159,6 +177,18 @@ $(document).ready(function() {
     $cont.append($input);
     $cont.data('count', index);
 
+  }
+
+  function addSlaveConstraints(e) {
+    var   $cont = $('#slave_constraints')
+        , index = $cont.data('count') + 1
+        , $input = createInput('slave_constraints', index)
+        ;
+
+    e.preventDefault();
+
+    $cont.append($input);
+    $cont.data('count', index);
   }
 
   function removeInput(e) {
@@ -172,6 +202,7 @@ $(document).ready(function() {
   $('#new_task #volumes .plus').on('click', addVolumes);
   $('#new_task #env .plus').on('click', addEnvironments);
   $('#new_task #uris .plus').on('click', addURIs);
+  $('#new_task #slave_constraints .plus').on('click', addSlaveConstraints);
   $('#new_task #cancel').on('click', function(e) {
     e.preventDefault();
     window.location = window.location;

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,11 +79,19 @@
                   </div>
                 </div>
                 <div class="field">
-                  <div class="field" id="uris" data-count=0>
-                    <label>
-                      URIs
-                      <i class="plus icon green add"></i>
-                    </label>
+                  <div class="two fields">
+                    <div class="field" id="uris" data-count=0>
+                      <label>
+                        URIs
+                        <i class="plus icon green add"></i>
+                      </label>
+                    </div>
+                    <div class="field" id="slave_constraints" data-count=0>
+                      <label>
+                        Slave Constraints
+                        <i class="plus icon green add"></i>
+                      </label>
+                    </div>
                   </div>
                 </div>
                 <div class="ui buttons right floated">

--- a/templates/task.html
+++ b/templates/task.html
@@ -12,9 +12,11 @@
     <body>
         <div class="ui fixed inverted menu">
             <div class="ui container">
-                <div class="header item">
-                    <img class="logo eremetic" src="/static/images/eremiteLOGO_02.png">
-                </div>
+                <a href="/">
+                    <div class="header item">
+                        <img class="logo eremetic" src="/static/images/eremiteLOGO_02.png">
+                    </div>
+                </a>
             </div>
         </div>
         <div class="ui main container">
@@ -91,6 +93,17 @@
                                 {{.Memory}}
                             </div>
                         </div>
+                        {{if .SlaveConstraints}}
+                            <div class="item" title="slave constraints">
+                                <i class="lock icon"></i>
+                                <div class="content">
+                                    <strong>Slave constraints:</strong>
+                                    {{range $index, $constraint := .SlaveConstraints}}
+                                        <br/>{{$constraint.AttributeName}}={{$constraint.AttributeValue}}
+                                    {{end}}
+                                </div>
+                            </div>
+                        {{end}}
                     </div>
                 </div>
                 <div class="column">

--- a/types/request.go
+++ b/types/request.go
@@ -1,12 +1,5 @@
 package types
 
-// Volume is a mapping between ContainerPath and HostPath, to allow Docker
-// to mount volumes.
-type Volume struct {
-	ContainerPath string `json:"container_path"`
-	HostPath      string `json:"host_path"`
-}
-
 // Request represents the structure of a job request
 type Request struct {
 	TaskCPUs          float64           `json:"task_cpus"`
@@ -17,6 +10,7 @@ type Request struct {
 	Volumes           []Volume          `json:"volumes"`
 	Environment       map[string]string `json:"env"`
 	MaskedEnvironment map[string]string `json:"masked_env"`
+	SlaveConstraints  []SlaveConstraint `json:"slave_constraint"`
 	CallbackURI       string            `json:"callback_uri"`
 	URIs              []string          `json:"uris"`
 }

--- a/types/request.go
+++ b/types/request.go
@@ -10,7 +10,7 @@ type Request struct {
 	Volumes           []Volume          `json:"volumes"`
 	Environment       map[string]string `json:"env"`
 	MaskedEnvironment map[string]string `json:"masked_env"`
-	SlaveConstraints  []SlaveConstraint `json:"slave_constraint"`
+	SlaveConstraints  []SlaveConstraint `json:"slave_constraints"`
 	CallbackURI       string            `json:"callback_uri"`
 	URIs              []string          `json:"uris"`
 }

--- a/types/task.go
+++ b/types/task.go
@@ -39,7 +39,7 @@ type EremeticTask struct {
 	Name              string            `json:"name"`
 	FrameworkId       string            `json:"framework_id"`
 	SlaveId           string            `json:"slave_id"`
-	SlaveConstraints  []SlaveConstraint `json:"slave_constraint"`
+	SlaveConstraints  []SlaveConstraint `json:"slave_constraints"`
 	Hostname          string            `json:"hostname"`
 	Retry             int               `json:"retry"`
 	CallbackURI       string            `json:"callback_uri"`

--- a/types/task.go
+++ b/types/task.go
@@ -13,6 +13,18 @@ type Status struct {
 	Status string `json:"status"`
 }
 
+// Volume is a mapping between ContainerPath and HostPath, to allow Docker
+// to mount volumes.
+type Volume struct {
+	ContainerPath string `json:"container_path"`
+	HostPath      string `json:"host_path"`
+}
+
+type SlaveConstraint struct {
+	AttributeName  string `json:"attribute_name"`
+	AttributeValue string `json:"attribute_value"`
+}
+
 type EremeticTask struct {
 	TaskCPUs          float64           `json:"task_cpus"`
 	TaskMem           float64           `json:"task_mem"`
@@ -27,6 +39,7 @@ type EremeticTask struct {
 	Name              string            `json:"name"`
 	FrameworkId       string            `json:"framework_id"`
 	SlaveId           string            `json:"slave_id"`
+	SlaveConstraints  []SlaveConstraint `json:"slave_constraint"`
 	Hostname          string            `json:"hostname"`
 	Retry             int               `json:"retry"`
 	CallbackURI       string            `json:"callback_uri"`
@@ -58,6 +71,7 @@ func NewEremeticTask(request Request) (EremeticTask, error) {
 		User:              "root",
 		Environment:       request.Environment,
 		MaskedEnvironment: request.MaskedEnvironment,
+		SlaveConstraints:  request.SlaveConstraints,
 		Image:             request.DockerImage,
 		Volumes:           request.Volumes,
 		CallbackURI:       request.CallbackURI,

--- a/types/task.go
+++ b/types/task.go
@@ -41,6 +41,7 @@ type EremeticTask struct {
 	SlaveId           string            `json:"slave_id"`
 	SlaveConstraints  []SlaveConstraint `json:"slave_constraints"`
 	Hostname          string            `json:"hostname"`
+	Port              int32             `json:"port"`
 	Retry             int               `json:"retry"`
 	CallbackURI       string            `json:"callback_uri"`
 	URIs              []string          `json:"uris"`


### PR DESCRIPTION
Fixes #78. 

Adds the following:

* Mesos slave attribute constraints to tasks; see README/examples updates for more details.
* Adds constraints UI to the create flow
* Adds a list of constraints to the UI of task view
* Add slave port to the task meta; this allows easier access to retrieving task results from mesos slaves