### PR TITLE
Create a database abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ create /etc/eremetic/eremetic.yml with:
     loglevel: DEBUG
     logformat: json
 
+## Database Backing
+Eremetic uses a BoltDB based database to store task information. The location of
+it can be set by adding
+
+    database: '/tmp/eremeticdb/eremetic.db'
+
+to the eremetic.yml
+
 ### Authentication
 To enable mesos framework authentication add the location of credential file to your configuration:
 

--- a/eremetic_test.go
+++ b/eremetic_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os/user"
 	"testing"
 
@@ -46,5 +48,29 @@ func TestMain(t *testing.T) {
 	Convey("setupLogging", t, func() {
 		setupLogging()
 		So(logrus.GetLevel(), ShouldEqual, logrus.DebugLevel)
+	})
+
+	Convey("setupDB", t, func() {
+		Convey("BoltDB", func() {
+			dir, _ := ioutil.TempDir("", "eremetic")
+			testDB := fmt.Sprintf("%s/test.db", dir)
+			viper.Set("database_driver", "boltdb")
+			viper.Set("database", testDB)
+
+			db, err := setupDB()
+
+			So(db, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Invalid configuration", func() {
+			viper.Set("database_driver", nil)
+			viper.Set("database", nil)
+
+			db, err := setupDB()
+
+			So(db, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
 	})
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -10,31 +10,33 @@ import (
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/mux"
 	"github.com/klarna/eremetic/assets"
+	"github.com/klarna/eremetic/database"
 	"github.com/klarna/eremetic/handler"
 	"github.com/klarna/eremetic/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Create is used to create a new router
-func Create(scheduler types.Scheduler) *mux.Router {
+func Create(scheduler types.Scheduler, database database.TaskDB) *mux.Router {
+	h := handler.Create(scheduler, database)
 	routes := types.Routes{
 		types.Route{
 			Name:    "AddTask",
 			Method:  "POST",
 			Pattern: "/task",
-			Handler: handler.AddTask(scheduler),
+			Handler: h.AddTask(),
 		},
 		types.Route{
 			Name:    "Status",
 			Method:  "GET",
 			Pattern: "/task/{taskId}",
-			Handler: handler.GetTaskInfo(scheduler),
+			Handler: h.GetTaskInfo(),
 		},
 		types.Route{
 			Name:    "ListRunningTasks",
 			Method:  "GET",
 			Pattern: "/task",
-			Handler: handler.ListRunningTasks(scheduler),
+			Handler: h.ListRunningTasks(),
 		},
 	}
 

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -1,17 +1,26 @@
 package routes
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/klarna/eremetic/database"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestRoutes(t *testing.T) {
 	routes := []string{"AddTask", "Status"}
 
+	dir, _ := os.Getwd()
+	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
+	if err != nil {
+		t.Fail()
+	}
+
 	Convey("Create", t, func() {
 		Convey("Should build the expected routes", func() {
-			m := Create(nil)
+			m := Create(nil, db)
 			for _, name := range routes {
 				So(m.GetRoute(name), ShouldNotBeNil)
 			}

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -24,7 +24,7 @@ func (r *Reconcile) Cancel() {
 	close(r.cancel)
 }
 
-func ReconcileTasks(driver sched.SchedulerDriver) *Reconcile {
+func ReconcileTasks(driver sched.SchedulerDriver, database database.TaskDB) *Reconcile {
 	cancel := make(chan struct{})
 	done := make(chan struct{})
 


### PR DESCRIPTION
In order to prepare for adding support for more different databases, an
abstraction for the database drivers is needed.