### PR TITLE
Refactor uris/fetch

### DIFF
--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -1,26 +1,11 @@
 package scheduler
 
 import (
-	"strings"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/klarna/eremetic/types"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesos/mesos-go/mesosutil"
 )
-
-var (
-	archiveSfx = []string{".tgz", ".tar.gz", ".tbz2", ".tar.bz2", ".txz", ".tar.xz", ".zip"}
-)
-
-func isArchive(url string) bool {
-	for _, s := range archiveSfx {
-		if strings.HasSuffix(url, s) {
-			return true
-		}
-	}
-	return false
-}
 
 func createTaskInfo(task types.EremeticTask, offer *mesos.Offer) (types.EremeticTask, *mesos.TaskInfo) {
 	task.FrameworkId = *offer.FrameworkId.Value
@@ -58,14 +43,7 @@ func createTaskInfo(task types.EremeticTask, offer *mesos.Offer) (types.Eremetic
 	}
 
 	var uris []*mesos.CommandInfo_URI
-	for _, v := range task.URIs {
-		uris = append(uris, &mesos.CommandInfo_URI{
-			Value:   proto.String(v),
-			Extract: proto.Bool(isArchive(v)),
-		})
-	}
-
-	for _, v := range task.Fetch {
+	for _, v := range task.FetchURIs {
 		uris = append(uris, &mesos.CommandInfo_URI{
 			Value:      proto.String(v.URI),
 			Extract:    proto.Bool(v.Extract),

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -85,91 +85,65 @@ func TestTask(t *testing.T) {
 			So(taskInfo.Command.Environment.Variables[1].GetValue(), ShouldEqual, eremeticTask.ID)
 		})
 
-		Convey("Given picture to download", func() {
-			eremeticTask.URIs = []string{"http://foobar.local/kitten.jpg"}
-
-			_, taskInfo := createTaskInfo(eremeticTask, &offer)
-
-			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
-			So(taskInfo.Command.Uris, ShouldHaveLength, 1)
-			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.URIs[0])
-			So(taskInfo.Command.Uris[0].GetExecutable(), ShouldBeFalse)
-			So(taskInfo.Command.Uris[0].GetExtract(), ShouldBeFalse)
-			So(taskInfo.Command.Uris[0].GetCache(), ShouldBeFalse)
-		})
-
-		Convey("Given archive to download", func() {
-			eremeticTask.URIs = []string{"http://foobar.local/cats.zip"}
-
-			_, taskInfo := createTaskInfo(eremeticTask, &offer)
-
-			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
-			So(taskInfo.Command.Uris, ShouldHaveLength, 1)
-			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.URIs[0])
-			So(taskInfo.Command.Uris[0].GetExecutable(), ShouldBeFalse)
-			So(taskInfo.Command.Uris[0].GetExtract(), ShouldBeTrue)
-			So(taskInfo.Command.Uris[0].GetCache(), ShouldBeFalse)
-		})
-
 		Convey("Given archive to fetch", func() {
-			fetch := []types.URI{types.URI{
+			URI := []types.URI{types.URI{
 				URI:     "http://foobar.local/cats.zip",
 				Extract: true,
 			}}
-			eremeticTask.Fetch = fetch
+			eremeticTask.FetchURIs = URI
 			_, taskInfo := createTaskInfo(eremeticTask, &offer)
 
 			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
 			So(taskInfo.Command.Uris, ShouldHaveLength, 1)
-			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.Fetch[0].URI)
+			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.FetchURIs[0].URI)
 			So(taskInfo.Command.Uris[0].GetExecutable(), ShouldBeFalse)
 			So(taskInfo.Command.Uris[0].GetExtract(), ShouldBeTrue)
 			So(taskInfo.Command.Uris[0].GetCache(), ShouldBeFalse)
 		})
 
 		Convey("Given archive to fetch and cache", func() {
-			fetch := []types.URI{types.URI{
+			URI := []types.URI{types.URI{
 				URI:     "http://foobar.local/cats.zip",
 				Extract: true,
 				Cache:   true,
 			}}
-			eremeticTask.Fetch = fetch
+			eremeticTask.FetchURIs = URI
 			_, taskInfo := createTaskInfo(eremeticTask, &offer)
 
 			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
 			So(taskInfo.Command.Uris, ShouldHaveLength, 1)
-			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.Fetch[0].URI)
+			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.FetchURIs[0].URI)
 			So(taskInfo.Command.Uris[0].GetExecutable(), ShouldBeFalse)
 			So(taskInfo.Command.Uris[0].GetExtract(), ShouldBeTrue)
 			So(taskInfo.Command.Uris[0].GetCache(), ShouldBeTrue)
 		})
 
 		Convey("Given image to fetch", func() {
-			fetch := []types.URI{types.URI{
+			URI := []types.URI{types.URI{
 				URI: "http://foobar.local/cats.jpeg",
 			}}
-			eremeticTask.Fetch = fetch
+			eremeticTask.FetchURIs = URI
 			_, taskInfo := createTaskInfo(eremeticTask, &offer)
 
 			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
 			So(taskInfo.Command.Uris, ShouldHaveLength, 1)
-			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.Fetch[0].URI)
+			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.FetchURIs[0].URI)
 			So(taskInfo.Command.Uris[0].GetExecutable(), ShouldBeFalse)
 			So(taskInfo.Command.Uris[0].GetExtract(), ShouldBeFalse)
 			So(taskInfo.Command.Uris[0].GetCache(), ShouldBeFalse)
 		})
 
 		Convey("Given script to fetch", func() {
-			fetch := []types.URI{types.URI{
+			URI := []types.URI{types.URI{
 				URI:        "http://foobar.local/cats.sh",
 				Executable: true,
 			}}
-			eremeticTask.Fetch = fetch
+			eremeticTask.FetchURIs = URI
 			_, taskInfo := createTaskInfo(eremeticTask, &offer)
 
 			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
 			So(taskInfo.Command.Uris, ShouldHaveLength, 1)
-			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.Fetch[0].URI)
+			So(taskInfo.Command.Uris[0].GetValue(), ShouldEqual, eremeticTask.FetchURIs[0].URI)
 			So(taskInfo.Command.Uris[0].GetExecutable(), ShouldBeTrue)
 			So(taskInfo.Command.Uris[0].GetExtract(), ShouldBeFalse)
 			So(taskInfo.Command.Uris[0].GetCache(), ShouldBeFalse)

--- a/types/task.go
+++ b/types/task.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/m4rw3r/uuid"
@@ -50,12 +51,42 @@ type EremeticTask struct {
 	Hostname          string            `json:"hostname"`
 	Retry             int               `json:"retry"`
 	CallbackURI       string            `json:"callback_uri"`
-	URIs              []string          `json:"uris"`
-	Fetch             []URI             `json:"fetch"`
 	SandboxPath       string            `json:"sandbox_path"`
 	AgentIP           string            `json:"agent_ip"`
 	AgentPort         int32             `json:"agent_port"`
 	ForcePullImage    bool              `json:"force_pull_image"`
+	FetchURIs         []URI             `json:"fetch"`
+}
+
+func isArchive(url string) bool {
+	var archiveSfx = []string{".tgz", ".tar.gz", ".tbz2", ".tar.bz2", ".txz", ".tar.xz", ".zip"}
+	for _, s := range archiveSfx {
+		if strings.HasSuffix(url, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeURIs(request Request) []URI {
+	var URIs []URI
+	for _, v := range request.URIs {
+		URIs = append(URIs, URI{
+			URI:        v,
+			Extract:    isArchive(v),
+			Cache:      false,
+			Executable: false,
+		})
+	}
+	for _, v := range request.Fetch {
+		URIs = append(URIs, URI{
+			URI:        v.URI,
+			Extract:    v.Extract,
+			Cache:      v.Cache,
+			Executable: v.Executable,
+		})
+	}
+	return URIs
 }
 
 func NewEremeticTask(request Request, name string) (EremeticTask, error) {
@@ -87,8 +118,7 @@ func NewEremeticTask(request Request, name string) (EremeticTask, error) {
 		Image:             request.DockerImage,
 		Volumes:           request.Volumes,
 		CallbackURI:       request.CallbackURI,
-		URIs:              request.URIs,
-		Fetch:             request.Fetch,
+		FetchURIs:         mergeURIs(request),
 	}
 	return task, nil
 }

--- a/types/task.go
+++ b/types/task.go
@@ -29,8 +29,8 @@ type SlaveConstraint struct {
 type URI struct {
 	URI        string `json:"uri"`
 	Executable bool   `json:"executable"`
-	Extract    bool   `json:"extract,omitempty"`
-	Cache      bool   `json:"cache,omitempty"`
+	Extract    bool   `json:"extract"`
+	Cache      bool   `json:"cache"`
 }
 
 type EremeticTask struct {

--- a/types/task_test.go
+++ b/types/task_test.go
@@ -192,14 +192,63 @@ func TestTask(t *testing.T) {
 			So(task.MaskedEnvironment["foo"], ShouldEqual, "bar")
 		})
 
-		Convey("Given uri to download", func() {
+		Convey("Given URI (via uris) to download", func() {
 			request.URIs = []string{"http://foobar.local/kitten.jpg"}
 
 			task, err := NewEremeticTask(request, "")
 
 			So(err, ShouldBeNil)
-			So(task.URIs, ShouldHaveLength, 1)
-			So(task.URIs, ShouldContain, request.URIs[0])
+			So(task.FetchURIs, ShouldHaveLength, 1)
+			So(task.FetchURIs[0].URI, ShouldEqual, request.URIs[0])
+			So(task.FetchURIs[0].Executable, ShouldBeFalse)
+			So(task.FetchURIs[0].Extract, ShouldBeFalse)
+			So(task.FetchURIs[0].Cache, ShouldBeFalse)
+		})
+
+		Convey("Given URI (via uris) to download and extract", func() {
+			request.URIs = []string{"http://foobar.local/kittens.tar.gz"}
+
+			task, err := NewEremeticTask(request, "")
+
+			So(err, ShouldBeNil)
+			So(task.FetchURIs, ShouldHaveLength, 1)
+			So(task.FetchURIs[0].URI, ShouldEqual, request.URIs[0])
+			So(task.FetchURIs[0].Executable, ShouldBeFalse)
+			So(task.FetchURIs[0].Extract, ShouldBeTrue)
+			So(task.FetchURIs[0].Cache, ShouldBeFalse)
+		})
+
+		Convey("Given URI (via fetch) to download and extract", func() {
+			request.Fetch = []URI{URI{
+				URI:     "http://foobar.local/kittens.tar.gz",
+				Extract: true,
+			}}
+
+			task, err := NewEremeticTask(request, "")
+
+			So(err, ShouldBeNil)
+			So(task.FetchURIs, ShouldHaveLength, 1)
+			So(task.FetchURIs[0].URI, ShouldEqual, request.Fetch[0].URI)
+			So(task.FetchURIs[0].Executable, ShouldBeFalse)
+			So(task.FetchURIs[0].Extract, ShouldBeTrue)
+			So(task.FetchURIs[0].Cache, ShouldBeFalse)
+		})
+
+		Convey("Given URI (via fetch) to download, cache and set executable", func() {
+			request.Fetch = []URI{URI{
+				URI:        "http://foobar.local/kittens.sh",
+				Executable: true,
+				Cache:      true,
+			}}
+
+			task, err := NewEremeticTask(request, "")
+
+			So(err, ShouldBeNil)
+			So(task.FetchURIs, ShouldHaveLength, 1)
+			So(task.FetchURIs[0].URI, ShouldEqual, request.Fetch[0].URI)
+			So(task.FetchURIs[0].Executable, ShouldBeTrue)
+			So(task.FetchURIs[0].Extract, ShouldBeFalse)
+			So(task.FetchURIs[0].Cache, ShouldBeTrue)
 		})
 
 		Convey("Given no Command", func() {


### PR DESCRIPTION
Move merging of uris/fetch from launch task to create tasks by
replacing URIs/Fetch element from EremeticTask to a single one, FetchURIs,
loosely based on mesos protobuf.
This change breaks the 1:1 mapping on request to task.