### PR TITLE
Return empty array instead of `null` when tasks list is empty

### DIFF
--- a/database/boltdb.go
+++ b/database/boltdb.go
@@ -114,7 +114,7 @@ func (db boltDriver) ReadUnmaskedTask(id string) (types.EremeticTask, error) {
 // ListNonTerminalTasks returns a list of tasks that are not yet finished in one
 // way or another.
 func (db boltDriver) ListNonTerminalTasks() ([]*types.EremeticTask, error) {
-	var tasks []*types.EremeticTask
+	tasks := []*types.EremeticTask{}
 
 	err := db.database.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("tasks"))

--- a/database/boltdb_test.go
+++ b/database/boltdb_test.go
@@ -204,4 +204,33 @@ func TestBoltDatabase(t *testing.T) {
 		task := tasks[0]
 		So(task.ID, ShouldEqual, "2345")
 	})
+
+	Convey("List non-terminal tasks no running task", t, func() {
+		setup()
+		defer teardown()
+		defer db.Close()
+
+		db.Clean()
+		db.PutTask(&types.EremeticTask{
+			ID: "1234",
+			Status: []types.Status{
+				types.Status{
+					Status: mesos.TaskState_TASK_STAGING.String(),
+					Time:   time.Now().Unix(),
+				},
+				types.Status{
+					Status: mesos.TaskState_TASK_RUNNING.String(),
+					Time:   time.Now().Unix(),
+				},
+				types.Status{
+					Status: mesos.TaskState_TASK_FINISHED.String(),
+					Time:   time.Now().Unix(),
+				},
+			},
+		})
+		tasks, err := db.ListNonTerminalTasks()
+		So(err, ShouldBeNil)
+		So(tasks, ShouldBeEmpty)
+		So(tasks, ShouldNotBeNil)
+	})
 }

--- a/database/zookeeper.go
+++ b/database/zookeeper.go
@@ -132,7 +132,7 @@ func (z zkDriver) ReadUnmaskedTask(id string) (types.EremeticTask, error) {
 }
 
 func (z zkDriver) ListNonTerminalTasks() ([]*types.EremeticTask, error) {
-	var tasks []*types.EremeticTask
+	tasks := []*types.EremeticTask{}
 	paths, _, _ := z.connection.Children(z.path)
 	for _, p := range paths {
 		t, err := z.ReadTask(p)

--- a/database/zookeeper_test.go
+++ b/database/zookeeper_test.go
@@ -279,6 +279,7 @@ func TestZKDatabase(t *testing.T) {
 
 			list, _ := db.ListNonTerminalTasks()
 			So(list, ShouldBeEmpty)
+			So(list, ShouldNotBeNil)
 			So(object.AssertCalled(t, "Get", "/testdb/1234"), ShouldBeTrue)
 			So(object.AssertCalled(t, "Children", "/testdb"), ShouldBeTrue)
 		})


### PR DESCRIPTION
go lint doesn't like it, but it's nicer for clients