### PR TITLE
Rmirica/add port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -H "Content-Type: application/json" \
      http://eremetic_server:8080/task
 ```
 
-These basic fields are required but you can also specify volumes, environment
+These basic fields are required but you can also specify volumes, ports, environment
 variables, and URIs for the mesos fetcher to download. See
 [examples.md](examples.md) for more examples on how to use eremetic.
 
@@ -42,6 +42,13 @@ JSON format:
     {
       "container_path": "/var/run/docker.sock",
       "host_path": "/var/run/docker.sock"
+    }
+  ],
+  // Array of Objects, ports to forward to the container
+  "ports": [
+    {
+      "container_port": 80,
+      "protocol": "tcp"
     }
   ],
   // Object, Environment variables to pass to the container

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -304,6 +304,7 @@ func (s *eremeticScheduler) ScheduleTask(request types.Request) (string, error) 
 		"docker_image":      request.DockerImage,
 		"command":           request.Command,
 		"slave_constraints": request.SlaveConstraints,
+		"ports":             request.Ports,
 	}).Debug("Adding task to queue")
 
 	task, err := types.NewEremeticTask(request, fmt.Sprintf("Eremetic task %s", nextID(s)))

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -126,6 +126,8 @@
 .volumes .field input,
 .env .field input,
 .uri .field input,
+.ports .field input,
+.ports .field select,
 .slave_constraints .field input {
   width: auto !important;
 }

--- a/static/js/eremetic.js
+++ b/static/js/eremetic.js
@@ -34,6 +34,13 @@ $(document).ready(function() {
       }, []);
     }
 
+    if (typeof json.ports !== "undefined") {
+      json.ports = json.ports.reduce(function(collector, element) {
+        collector.push({ 'container_port': parseInt(element.container_port), 'protocol': element.protocol });
+        return collector;
+      }, []);
+    }
+
     json.task_cpus = parseFloat(json.task_cpus);
     json.task_mem = parseFloat(json.task_mem);
 
@@ -143,6 +150,36 @@ $(document).ready(function() {
 
   }
 
+  function addPorts(e) {
+    var   $cont = $('#ports')
+        , index = $cont.data('count') + 1
+        , $input
+        ;
+
+    e.preventDefault();
+
+    $input = $(
+      '<div class="field ui action input ports">' +
+        '<div class="field">' +
+          '<input name="ports[' + index + '][container_port]" placeholder="Container Port" type="number"/>' +
+        '</div>' +
+        '<div class="field">' +
+            '<select name="ports[' + index + '][protocol]">' +
+                '<option value="tcp" selected="selected">tcp</option>' +
+                '<option value="udp">udp</option>' +
+            '</select>' +
+        '</div>' +
+        '&nbsp;<button class="ui icon button">' +
+          '<i class="minus red icon"></i>' +
+        '</button>' +
+      '</div>'
+    );
+
+    $cont.append($input);
+    $cont.data('count', index);
+
+  }
+
   function addEnvironments(e) {
     var   $cont = $('#env')
         , index = $cont.data('count') + 1
@@ -200,6 +237,7 @@ $(document).ready(function() {
   $('#new_task').on('submit', submitHandler);
   $('#new_task #submit').on('click', submitHandler);
   $('#new_task #volumes .plus').on('click', addVolumes);
+  $('#new_task #ports .plus').on('click', addPorts);
   $('#new_task #env .plus').on('click', addEnvironments);
   $('#new_task #uris .plus').on('click', addURIs);
   $('#new_task #slave_constraints .plus').on('click', addSlaveConstraints);

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,6 +97,16 @@
                     </div>
                   </div>
                 </div>
+                <div class="field">
+                  <div class="two fields">
+                    <div class="field" id="ports" data-count=0>
+                      <label>
+                        Ports
+                        <i class="plus icon green add"></i>
+                      </label>
+                    </div>
+                  </div>
+                </div>
                 <div class="ui buttons right floated">
                   <button class="ui button" id="cancel">Cancel</button>
                   <div class="or"></div>

--- a/types/request.go
+++ b/types/request.go
@@ -7,6 +7,7 @@ type Request struct {
 	DockerImage       string            `json:"docker_image"`
 	Command           string            `json:"command"`
 	Volumes           []Volume          `json:"volumes"`
+	Ports             []Port            `json:"ports"`
 	Environment       map[string]string `json:"env"`
 	MaskedEnvironment map[string]string `json:"masked_env"`
 	SlaveConstraints  []SlaveConstraint `json:"slave_constraints"`

--- a/types/task.go
+++ b/types/task.go
@@ -20,6 +20,12 @@ type Volume struct {
 	HostPath      string `json:"host_path"`
 }
 
+type Port struct {
+	ContainerPort uint32 `json:"container_port"`
+	HostPort      uint32 `json:"host_port"`
+	Protocol      string `json:"protocol"`
+}
+
 type SlaveConstraint struct {
 	AttributeName  string `json:"attribute_name"`
 	AttributeValue string `json:"attribute_value"`
@@ -41,6 +47,7 @@ type EremeticTask struct {
 	MaskedEnvironment map[string]string `json:"masked_env"`
 	Image             string            `json:"image"`
 	Volumes           []Volume          `json:"volumes"`
+	Ports             []Port            `json:"ports"`
 	Status            []Status          `json:"status"`
 	ID                string            `json:"id"`
 	Name              string            `json:"name"`
@@ -116,6 +123,7 @@ func NewEremeticTask(request Request, name string) (EremeticTask, error) {
 		SlaveConstraints:  request.SlaveConstraints,
 		Image:             request.DockerImage,
 		Volumes:           request.Volumes,
+		Ports:             request.Ports,
 		CallbackURI:       request.CallbackURI,
 		ForcePullImage:    request.ForcePullImage,
 		FetchURIs:         mergeURIs(request),


### PR DESCRIPTION
I gave a shot at this naive implementation of a portMapping allocator.

It expects a `"ports":[{"containerPort":<internal port>, "protocol": "<protocol>"}]` definition in the task POST json.

It will select the first available ports from the mesos offer and allocate them accordingly.

I've abandoned the attempt to write an offer matcher for port-range (I don't expect this to be a problem in practice but this should be solved)