### PR TITLE
Extract scheduler tests into smaller ones

### DIFF
--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -39,7 +39,7 @@ func callbackReceiver() (chan callbackData, *httptest.Server) {
 	return cb, ts
 }
 
-func TestScheduler_Scheduling(t *testing.T) {
+func TestScheduler(t *testing.T) {
 	logrus.SetOutput(ioutil.Discard)
 
 	dir, _ := os.Getwd()
@@ -116,20 +116,6 @@ func TestScheduler_Scheduling(t *testing.T) {
 			s.Error(nil, "Error")
 		})
 	})
-}
-
-func TestScheduler_ResourceOffers(t *testing.T) {
-	logrus.SetOutput(ioutil.Discard)
-
-	dir, _ := os.Getwd()
-	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
-	if err != nil || db == nil {
-		t.Error("Foo")
-		t.Fail()
-	}
-	db.Clean()
-	defer db.Close()
-
 	Convey("Given a scheduler with one scheduled task", t, func() {
 		s := &eremeticScheduler{
 			tasks:    make(chan string, 1),
@@ -224,20 +210,6 @@ func TestScheduler_ResourceOffers(t *testing.T) {
 			})
 		})
 	})
-}
-
-func TestScheduler_StatusUpdate(t *testing.T) {
-	logrus.SetOutput(ioutil.Discard)
-
-	dir, _ := os.Getwd()
-	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
-	if err != nil || db == nil {
-		t.Error("Foo")
-		t.Fail()
-	}
-	db.Clean()
-	defer db.Close()
-
 	Convey("Given a scheduler with one scheduled task", t, func() {
 		s := &eremeticScheduler{
 			tasks:    make(chan string, 1),
@@ -423,20 +395,6 @@ func TestScheduler_StatusUpdate(t *testing.T) {
 			})
 		})
 	})
-}
-
-func TestScheduler_FrameworkMessage(t *testing.T) {
-	logrus.SetOutput(ioutil.Discard)
-
-	dir, _ := os.Getwd()
-	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
-	if err != nil || db == nil {
-		t.Error("Foo")
-		t.Fail()
-	}
-	db.Clean()
-	defer db.Close()
-
 	Convey("Given a scheduler with one scheduled task", t, func() {
 		s := &eremeticScheduler{
 			tasks:    make(chan string, 1),
@@ -473,20 +431,6 @@ func TestScheduler_FrameworkMessage(t *testing.T) {
 			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, "not a json")
 		})
 	})
-}
-
-func TestScheduler_ScheduleTask(t *testing.T) {
-	logrus.SetOutput(ioutil.Discard)
-
-	dir, _ := os.Getwd()
-	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
-	if err != nil || db == nil {
-		t.Error("Foo")
-		t.Fail()
-	}
-	db.Clean()
-	defer db.Close()
-
 	Convey("Given a scheduler with no scheduled tasks", t, func() {
 		scheduler := &eremeticScheduler{
 			tasks:    make(chan string, 1),
@@ -540,20 +484,6 @@ func TestScheduler_ScheduleTask(t *testing.T) {
 			})
 		})
 	})
-}
-
-func TestScheduler_GenerateID(t *testing.T) {
-	logrus.SetOutput(ioutil.Discard)
-
-	dir, _ := os.Getwd()
-	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
-	if err != nil || db == nil {
-		t.Error("Foo")
-		t.Fail()
-	}
-	db.Clean()
-	defer db.Close()
-
 	Convey("Given a scheduler with no scheduled tasks", t, func() {
 		scheduler := &eremeticScheduler{
 			tasks:    make(chan string, 100),

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/klarna/eremetic"
 	"github.com/klarna/eremetic/database"
@@ -38,7 +39,9 @@ func callbackReceiver() (chan callbackData, *httptest.Server) {
 	return cb, ts
 }
 
-func TestScheduler(t *testing.T) {
+func TestScheduler_Scheduling(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+
 	dir, _ := os.Getwd()
 	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
 	if err != nil || db == nil {
@@ -48,305 +51,449 @@ func TestScheduler(t *testing.T) {
 	db.Clean()
 	defer db.Close()
 
-	Convey("eremeticScheduler", t, func() {
+	Convey("Given a scheduler with one scheduled task", t, func() {
 		s := &eremeticScheduler{
 			tasks:    make(chan string, 1),
 			database: db,
 		}
+
 		id := "eremetic-task.9999"
+
 		db.PutTask(&eremetic.Task{ID: id})
 
-		Convey("Create", func() {
+		Convey("When creating a new scheduler", func() {
 			s = Create(&Settings{MaxQueueSize: 200}, db)
-			So(s.tasksCreated, ShouldEqual, 0)
-			So(cap(s.tasks), ShouldEqual, 200)
+
+			Convey("The settings should have default values", func() {
+				So(s.tasksCreated, ShouldEqual, 0)
+				So(cap(s.tasks), ShouldEqual, 200)
+			})
 		})
 
-		Convey("API", func() {
-			Convey("Registered", func() {
-				driver := NewMockScheduler()
-				driver.On("ReconcileTasks").Return("ok").Once()
-				fID := mesos.FrameworkID{Value: proto.String("1234")}
-				mInfo := mesos.MasterInfo{}
-				s.Registered(driver, &fID, &mInfo)
+		Convey("When the scheduler is registered", func() {
+			driver := NewMockScheduler()
+			driver.On("ReconcileTasks").Return("ok").Once()
+
+			fid := mesos.FrameworkID{Value: proto.String("1234")}
+			info := mesos.MasterInfo{}
+
+			s.Registered(driver, &fid, &info)
+
+			Convey("The tasks should be reconciled", func() {
 				So(driver.AssertCalled(t, "ReconcileTasks"), ShouldBeTrue)
 			})
+		})
 
-			Convey("Reregistered", func() {
-				driver := NewMockScheduler()
-				driver.On("ReconcileTasks").Return("ok").Once()
-				db.Clean()
-				s.Reregistered(driver, &mesos.MasterInfo{})
+		Convey("When the scheduler is reregistered", func() {
+			driver := NewMockScheduler()
+			driver.On("ReconcileTasks").Return("ok").Once()
+			db.Clean()
+
+			s.Reregistered(driver, &mesos.MasterInfo{})
+
+			Convey("The tasks should be reconciled", func() {
 				So(driver.AssertCalled(t, "ReconcileTasks"), ShouldBeTrue)
 			})
+		})
 
-			Convey("Disconnected", func() {
-				s.Disconnected(nil)
+		Convey("When the scheduler is disconnected", func() {
+			s.Disconnected(nil)
+		})
+
+		Convey("When an offer rescinded", func() {
+			s.OfferRescinded(nil, &mesos.OfferID{})
+		})
+
+		Convey("When a slave was lost", func() {
+			s.SlaveLost(nil, &mesos.SlaveID{})
+		})
+
+		Convey("When an executor was lost", func() {
+			s.ExecutorLost(nil, &mesos.ExecutorID{}, &mesos.SlaveID{}, 2)
+		})
+
+		Convey("When there was an error", func() {
+			s.Error(nil, "Error")
+		})
+	})
+}
+
+func TestScheduler_ResourceOffers(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+
+	dir, _ := os.Getwd()
+	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
+	if err != nil || db == nil {
+		t.Error("Foo")
+		t.Fail()
+	}
+	db.Clean()
+	defer db.Close()
+
+	Convey("Given a scheduler with one scheduled task", t, func() {
+		s := &eremeticScheduler{
+			tasks:    make(chan string, 1),
+			database: db,
+		}
+
+		id := "eremetic-task.9999"
+
+		db.PutTask(&eremetic.Task{ID: id})
+
+		driver := NewMockScheduler()
+
+		Convey("When there are no offers", func() {
+			offers := []*mesos.Offer{}
+			s.ResourceOffers(driver, offers)
+
+			Convey("No offers should be declined", func() {
+				So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
 			})
-
-			Convey("ResourceOffers", func() {
-				driver := NewMockScheduler()
-
-				Convey("No offers", func() {
-					offers := []*mesos.Offer{}
-					s.ResourceOffers(driver, offers)
-					So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
-					So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
-				})
-
-				Convey("No tasks", func() {
-					offers := []*mesos.Offer{
-						offer("1234", 1.0, 128),
-					}
-					driver.On("DeclineOffer").Return("declined").Once()
-					s.ResourceOffers(driver, offers)
-					So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
-					So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
-				})
-
-				Convey("One task able to launch", func() {
-					offers := []*mesos.Offer{
-						offer("1234", 1.0, 128),
-					}
-					driver.On("LaunchTasks").Return("launched").Once()
-
-					taskID, err := s.ScheduleTask(eremetic.Request{
-						TaskCPUs:    0.5,
-						TaskMem:     22.0,
-						DockerImage: "busybox",
-						Command:     "echo hello",
-					})
-
-					So(err, ShouldBeNil)
-					s.ResourceOffers(driver, offers)
-
-					task, err := db.ReadTask(taskID)
-					So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
-					So(driver.AssertCalled(t, "LaunchTasks"), ShouldBeTrue)
-					So(task.Status, ShouldHaveLength, 2)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
-					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_STAGING)
-				})
-
-				Convey("One task unable to launch", func() {
-					offers := []*mesos.Offer{
-						offer("1234", 1.0, 128),
-					}
-					driver.On("DeclineOffer").Return("declined").Once()
-
-					_, err := s.ScheduleTask(eremetic.Request{
-						TaskCPUs:    1.5,
-						TaskMem:     22.0,
-						DockerImage: "busybox",
-						Command:     "echo hello",
-					})
-
-					So(err, ShouldBeNil)
-					s.ResourceOffers(driver, offers)
-
-					So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
-					So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
-				})
+			Convey("No tasks should be launched", func() {
+				So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
 			})
+		})
+		Convey("When there are no tasks", func() {
+			offers := []*mesos.Offer{
+				offer("1234", 1.0, 128),
+			}
+			driver.On("DeclineOffer").Return("declined").Once()
 
-			Convey("StatusUpdate", func() {
-				Convey("Running then failing", func() {
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_RUNNING.Enum(),
-					})
-					task, _ := db.ReadTask(id)
-					So(len(task.Status), ShouldEqual, 1)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
+			s.ResourceOffers(driver, offers)
 
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_FAILED.Enum(),
-					})
-					task, _ = db.ReadTask(id)
-
-					So(len(task.Status), ShouldEqual, 2)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
-					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
-				})
-
-				Convey("Failing immediately", func() {
-					s.tasks = make(chan string, 100)
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_FAILED.Enum(),
-					})
-					task, _ := db.ReadTask(id)
-					So(len(task.Status), ShouldEqual, 2)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
-					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
-
-					select {
-					case c := <-s.tasks:
-						So(c, ShouldEqual, id)
-					}
-				})
-
-				Convey("Task finished callback", func() {
-					cb, ts := callbackReceiver()
-					defer ts.Close()
-
-					id := "eremetic-task.1000"
-					db.PutTask(&eremetic.Task{
-						ID:          id,
-						CallbackURI: ts.URL,
-					})
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_FINISHED.Enum(),
-					})
-
-					select {
-					case c := <-cb:
-						So(c.TaskID, ShouldEqual, id)
-						So(c.Status, ShouldEqual, "TASK_FINISHED")
-					}
-				})
-
-				Convey("Task failed callback", func() {
-					cb, ts := callbackReceiver()
-					defer ts.Close()
-
-					id := "eremetic-task.1001"
-					db.PutTask(&eremetic.Task{
-						ID:          id,
-						CallbackURI: ts.URL,
-					})
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_RUNNING.Enum(),
-					})
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_FAILED.Enum(),
-					})
-
-					select {
-					case c := <-cb:
-						So(c.TaskID, ShouldEqual, id)
-						So(c.Status, ShouldEqual, "TASK_FAILED")
-					}
-				})
-
-				Convey("Task retry callback", func() {
-					cb, ts := callbackReceiver()
-					defer ts.Close()
-
-					id := "eremetic-task.1002"
-					db.PutTask(&eremetic.Task{
-						ID:          id,
-						CallbackURI: ts.URL,
-					})
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_FAILED.Enum(),
-					})
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_RUNNING.Enum(),
-					})
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						State: mesos.TaskState_TASK_FINISHED.Enum(),
-					})
-
-					select {
-					case c := <-cb:
-						So(c.TaskID, ShouldEqual, id)
-						So(c.Status, ShouldEqual, "TASK_FINISHED")
-					}
-				})
-
-				Convey("Updates sandbox", func() {
-					id := "eremetic-task.1003"
-					s.StatusUpdate(nil, &mesos.TaskStatus{
-						TaskId: &mesos.TaskID{
-							Value: proto.String(id),
-						},
-						Data:  []byte(`[{"Mounts":[{"Source":"/tmp/mesos/slaves/<agent_id>/frameworks/<framework_id>/executors/<task_id>/runs/<container_id>","Destination":"/mnt/mesos/sandbox","Mode":"","RW":true}]}]`),
-						State: mesos.TaskState_TASK_RUNNING.Enum(),
-					})
-					task, _ := db.ReadTask(id)
-					So(task.SandboxPath, ShouldNotBeEmpty)
-				})
+			Convey("The offer should be declined", func() {
+				So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
 			})
-
-			Convey("FrameworkMessage", func() {
-				driver := NewMockScheduler()
-				message := `{"message": "this is a message"}`
-				Convey("From Eremetic", func() {
-					source := "eremetic-executor"
-					executor := mesos.ExecutorID{
-						Value: proto.String(source),
-					}
-					s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
-				})
-
-				Convey("From an unknown source", func() {
-					source := "other-source"
-					executor := mesos.ExecutorID{
-						Value: proto.String(source),
-					}
-					s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
-				})
-
-				Convey("A bad json", func() {
-					source := "eremetic-executor"
-					executor := mesos.ExecutorID{
-						Value: proto.String(source),
-					}
-					s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, "not a json")
-				})
+			Convey("No tasks should be launched", func() {
+				So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
 			})
+		})
+		Convey("When a task is able to launch", func() {
+			offers := []*mesos.Offer{
+				offer("1234", 1.0, 128),
+			}
+			driver.On("LaunchTasks").Return("launched").Once()
 
-			Convey("OfferRescinded", func() {
-				s.OfferRescinded(nil, &mesos.OfferID{})
+			taskID, err := s.ScheduleTask(eremetic.Request{
+				TaskCPUs:    0.5,
+				TaskMem:     22.0,
+				DockerImage: "busybox",
+				Command:     "echo hello",
 			})
+			So(err, ShouldBeNil)
 
-			Convey("SlaveLost", func() {
-				s.SlaveLost(nil, &mesos.SlaveID{})
+			s.ResourceOffers(driver, offers)
+
+			task, err := db.ReadTask(taskID)
+			So(err, ShouldBeNil)
+
+			Convey("The task should contain the status history", func() {
+				So(task.Status, ShouldHaveLength, 2)
+				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
+				So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_STAGING)
 			})
-
-			Convey("ExecutorLost", func() {
-				s.ExecutorLost(nil, &mesos.ExecutorID{}, &mesos.SlaveID{}, 2)
+			Convey("The offer should not be declined", func() {
+				So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
 			})
+			Convey("The tasks should be launched", func() {
+				So(driver.AssertCalled(t, "LaunchTasks"), ShouldBeTrue)
+			})
+		})
 
-			Convey("Error", func() {
-				s.Error(nil, "Error")
+		Convey("When a task unable to launch", func() {
+			offers := []*mesos.Offer{
+				offer("1234", 1.0, 128),
+			}
+			driver.On("DeclineOffer").Return("declined").Once()
+
+			_, err := s.ScheduleTask(eremetic.Request{
+				TaskCPUs:    1.5,
+				TaskMem:     22.0,
+				DockerImage: "busybox",
+				Command:     "echo hello",
+			})
+			So(err, ShouldBeNil)
+
+			s.ResourceOffers(driver, offers)
+
+			Convey("The offer should be declined", func() {
+				So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
+			})
+			Convey("The tasks should not be launched", func() {
+				So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
 			})
 		})
 	})
+}
 
-	Convey("ScheduleTask", t, func() {
-		Convey("Given a valid Request", func() {
-			scheduler := &eremeticScheduler{
-				tasks:    make(chan string, 100),
-				database: db,
+func TestScheduler_StatusUpdate(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+
+	dir, _ := os.Getwd()
+	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
+	if err != nil || db == nil {
+		t.Error("Foo")
+		t.Fail()
+	}
+	db.Clean()
+	defer db.Close()
+
+	Convey("Given a scheduler with one scheduled task", t, func() {
+		s := &eremeticScheduler{
+			tasks:    make(chan string, 1),
+			database: db,
+		}
+
+		id := "eremetic-task.9999"
+
+		db.PutTask(&eremetic.Task{ID: id})
+
+		Convey("When a running task fails", func() {
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_RUNNING.Enum(),
+			})
+
+			task, err := db.ReadTask(id)
+			So(err, ShouldBeNil)
+
+			So(len(task.Status), ShouldEqual, 1)
+			So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_FAILED.Enum(),
+			})
+
+			task, err = db.ReadTask(id)
+			So(err, ShouldBeNil)
+
+			Convey("The task status history should contain the failed status", func() {
+				So(len(task.Status), ShouldEqual, 2)
+				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
+				So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
+			})
+		})
+
+		Convey("When a task fails immediately", func() {
+			s.tasks = make(chan string, 100)
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_FAILED.Enum(),
+			})
+
+			task, err := db.ReadTask(id)
+			So(err, ShouldBeNil)
+
+			Convey("The task should have a queued status", func() {
+				So(len(task.Status), ShouldEqual, 2)
+				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
+				So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
+			})
+
+			Convey("The task should be published on channel", func() {
+				c := <-s.tasks
+
+				So(c, ShouldEqual, id)
+			})
+		})
+
+		Convey("When a task finishes with a callback specified", func() {
+			cb, ts := callbackReceiver()
+			defer ts.Close()
+
+			id := "eremetic-task.1000"
+
+			db.PutTask(&eremetic.Task{
+				ID:          id,
+				CallbackURI: ts.URL,
+			})
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_FINISHED.Enum(),
+			})
+
+			Convey("The callback data should be available", func() {
+				c := <-cb
+
+				So(c.TaskID, ShouldEqual, id)
+				So(c.Status, ShouldEqual, "TASK_FINISHED")
+			})
+		})
+
+		Convey("When a task fails with a callback specified", func() {
+			cb, ts := callbackReceiver()
+			defer ts.Close()
+
+			id := "eremetic-task.1001"
+
+			db.PutTask(&eremetic.Task{
+				ID:          id,
+				CallbackURI: ts.URL,
+			})
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_RUNNING.Enum(),
+			})
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_FAILED.Enum(),
+			})
+
+			Convey("The callback data should be available", func() {
+				c := <-cb
+
+				So(c.TaskID, ShouldEqual, id)
+				So(c.Status, ShouldEqual, "TASK_FAILED")
+			})
+		})
+
+		Convey("When a task retries with a callback specified", func() {
+			cb, ts := callbackReceiver()
+			defer ts.Close()
+
+			id := "eremetic-task.1002"
+
+			db.PutTask(&eremetic.Task{
+				ID:          id,
+				CallbackURI: ts.URL,
+			})
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_FAILED.Enum(),
+			})
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_RUNNING.Enum(),
+			})
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				State: mesos.TaskState_TASK_FINISHED.Enum(),
+			})
+
+			Convey("The callback data should be available", func() {
+				c := <-cb
+
+				So(c.TaskID, ShouldEqual, id)
+				So(c.Status, ShouldEqual, "TASK_FINISHED")
+			})
+		})
+
+		Convey("When the sandbox is updated", func() {
+			id := "eremetic-task.1003"
+
+			s.StatusUpdate(nil, &mesos.TaskStatus{
+				TaskId: &mesos.TaskID{
+					Value: proto.String(id),
+				},
+				Data:  []byte(`[{"Mounts":[{"Source":"/tmp/mesos/slaves/<agent_id>/frameworks/<framework_id>/executors/<task_id>/runs/<container_id>","Destination":"/mnt/mesos/sandbox","Mode":"","RW":true}]}]`),
+				State: mesos.TaskState_TASK_RUNNING.Enum(),
+			})
+
+			task, err := db.ReadTask(id)
+			So(err, ShouldBeNil)
+
+			Convey("There should be a path to the sandbox", func() {
+				So(task.SandboxPath, ShouldNotBeEmpty)
+			})
+		})
+	})
+}
+
+func TestScheduler_FrameworkMessage(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+
+	dir, _ := os.Getwd()
+	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
+	if err != nil || db == nil {
+		t.Error("Foo")
+		t.Fail()
+	}
+	db.Clean()
+	defer db.Close()
+
+	Convey("Given a scheduler with one scheduled task", t, func() {
+		s := &eremeticScheduler{
+			tasks:    make(chan string, 1),
+			database: db,
+		}
+
+		id := "eremetic-task.9999"
+		db.PutTask(&eremetic.Task{ID: id})
+
+		driver := NewMockScheduler()
+		message := `{"message": "this is a message"}`
+
+		Convey("When receiving a framework message from Eremetic", func() {
+			source := "eremetic-executor"
+			executor := mesos.ExecutorID{
+				Value: proto.String(source),
 			}
+			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
+		})
 
+		Convey("When receiving a framework message from an unknown source", func() {
+			source := "other-source"
+			executor := mesos.ExecutorID{
+				Value: proto.String(source),
+			}
+			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
+		})
+
+		Convey("When the framework message format is invalid", func() {
+			source := "eremetic-executor"
+			executor := mesos.ExecutorID{
+				Value: proto.String(source),
+			}
+			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, "not a json")
+		})
+	})
+}
+
+func TestScheduler_ScheduleTask(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+
+	dir, _ := os.Getwd()
+	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
+	if err != nil || db == nil {
+		t.Error("Foo")
+		t.Fail()
+	}
+	db.Clean()
+	defer db.Close()
+
+	Convey("Given a scheduler with no scheduled tasks", t, func() {
+		scheduler := &eremeticScheduler{
+			tasks:    make(chan string, 1),
+			database: db,
+		}
+
+		Convey("When scheduling a task", func() {
 			request := eremetic.Request{
 				TaskCPUs:    0.5,
 				TaskMem:     22.0,
@@ -354,31 +501,29 @@ func TestScheduler(t *testing.T) {
 				Command:     "echo hello",
 			}
 
-			Convey("It should put a task id on the channel", func() {
-				taskID, err := scheduler.ScheduleTask(request)
+			taskID, err := scheduler.ScheduleTask(request)
+			So(err, ShouldBeNil)
 
+			Convey("It should put a task id on the channel", func() {
+				c := <-scheduler.tasks
+				So(c, ShouldEqual, taskID)
+			})
+
+			Convey("The task should be present in the database", func() {
+				task, err := db.ReadTask(taskID)
 				So(err, ShouldBeNil)
 
-				select {
-				case c := <-scheduler.tasks:
-					So(c, ShouldEqual, taskID)
-					task, _ := db.ReadTask(taskID)
-					So(task.TaskCPUs, ShouldEqual, request.TaskCPUs)
-					So(task.TaskMem, ShouldEqual, request.TaskMem)
-					So(task.Command, ShouldEqual, request.Command)
-					So(task.User, ShouldEqual, "root")
-					So(task.Environment, ShouldBeEmpty)
-					So(task.Image, ShouldEqual, request.DockerImage)
-					So(task.ID, ShouldStartWith, "eremetic-task.")
-				}
+				So(task.TaskCPUs, ShouldEqual, request.TaskCPUs)
+				So(task.TaskMem, ShouldEqual, request.TaskMem)
+				So(task.Command, ShouldEqual, request.Command)
+				So(task.User, ShouldEqual, "root")
+				So(task.Environment, ShouldBeEmpty)
+				So(task.Image, ShouldEqual, request.DockerImage)
+				So(task.ID, ShouldStartWith, "eremetic-task.")
 			})
 		})
 
-		Convey("When the queue channel is full", func() {
-			scheduler := &eremeticScheduler{
-				tasks:    make(chan string, 1),
-				database: db,
-			}
+		Convey("When scheduling a task and the queue is full", func() {
 			scheduler.tasks <- "dummy"
 
 			request := eremetic.Request{
@@ -388,24 +533,39 @@ func TestScheduler(t *testing.T) {
 				Command:     "echo hello",
 			}
 
-			Convey("It should return an error", func() {
-				_, err := scheduler.ScheduleTask(request)
+			_, err := scheduler.ScheduleTask(request)
 
+			Convey("It should return an error", func() {
 				So(err, ShouldNotBeNil)
 			})
 		})
 	})
+}
 
-	Convey("nextID", t, func() {
+func TestScheduler_GenerateID(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+
+	dir, _ := os.Getwd()
+	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))
+	if err != nil || db == nil {
+		t.Error("Foo")
+		t.Fail()
+	}
+	db.Clean()
+	defer db.Close()
+
+	Convey("Given a scheduler with no scheduled tasks", t, func() {
 		scheduler := &eremeticScheduler{
 			tasks:    make(chan string, 100),
 			database: db,
 		}
 
-		Convey("Generates a random string", func() {
+		Convey("When generating a random string", func() {
 			str := nextID(scheduler)
 
-			So(str, ShouldNotBeEmpty)
+			Convey("The string should not be empty", func() {
+				So(str, ShouldNotBeEmpty)
+			})
 		})
 	})
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -52,7 +52,7 @@ func TestScheduler(t *testing.T) {
 	defer db.Close()
 
 	Convey("Scheduling", t, func() {
-		Convey("Given a scheduler with one scheduled task", func() {
+		Convey("Given a scheduler with one task", func() {
 			s := &eremeticScheduler{
 				tasks:    make(chan string, 1),
 				database: db,
@@ -119,7 +119,7 @@ func TestScheduler(t *testing.T) {
 		})
 	})
 	Convey("ResourceOffers", t, func() {
-		Convey("Given a scheduler with one scheduled task", func() {
+		Convey("Given a scheduler with one task", func() {
 			s := &eremeticScheduler{
 				tasks:    make(chan string, 1),
 				database: db,
@@ -215,7 +215,7 @@ func TestScheduler(t *testing.T) {
 		})
 	})
 	Convey("StatusUpdate", t, func() {
-		Convey("Given a scheduler with one scheduled task", func() {
+		Convey("Given a scheduler with one task", func() {
 			s := &eremeticScheduler{
 				tasks:    make(chan string, 1),
 				database: db,
@@ -402,7 +402,7 @@ func TestScheduler(t *testing.T) {
 		})
 	})
 	Convey("FrameworkMessage", t, func() {
-		Convey("Given a scheduler with one scheduled task", func() {
+		Convey("Given a scheduler with one task", func() {
 			s := &eremeticScheduler{
 				tasks:    make(chan string, 1),
 				database: db,

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -51,450 +51,462 @@ func TestScheduler(t *testing.T) {
 	db.Clean()
 	defer db.Close()
 
-	Convey("Given a scheduler with one scheduled task", t, func() {
-		s := &eremeticScheduler{
-			tasks:    make(chan string, 1),
-			database: db,
-		}
+	Convey("Scheduling", t, func() {
+		Convey("Given a scheduler with one scheduled task", func() {
+			s := &eremeticScheduler{
+				tasks:    make(chan string, 1),
+				database: db,
+			}
 
-		id := "eremetic-task.9999"
+			id := "eremetic-task.9999"
 
-		db.PutTask(&eremetic.Task{ID: id})
+			db.PutTask(&eremetic.Task{ID: id})
 
-		Convey("When creating a new scheduler", func() {
-			s = Create(&Settings{MaxQueueSize: 200}, db)
+			Convey("When creating a new scheduler", func() {
+				s = Create(&Settings{MaxQueueSize: 200}, db)
 
-			Convey("The settings should have default values", func() {
-				So(s.tasksCreated, ShouldEqual, 0)
-				So(cap(s.tasks), ShouldEqual, 200)
+				Convey("The settings should have default values", func() {
+					So(s.tasksCreated, ShouldEqual, 0)
+					So(cap(s.tasks), ShouldEqual, 200)
+				})
+			})
+
+			Convey("When the scheduler is registered", func() {
+				driver := NewMockScheduler()
+				driver.On("ReconcileTasks").Return("ok").Once()
+
+				fid := mesos.FrameworkID{Value: proto.String("1234")}
+				info := mesos.MasterInfo{}
+
+				s.Registered(driver, &fid, &info)
+
+				Convey("The tasks should be reconciled", func() {
+					So(driver.AssertCalled(t, "ReconcileTasks"), ShouldBeTrue)
+				})
+			})
+
+			Convey("When the scheduler is reregistered", func() {
+				driver := NewMockScheduler()
+				driver.On("ReconcileTasks").Return("ok").Once()
+				db.Clean()
+
+				s.Reregistered(driver, &mesos.MasterInfo{})
+
+				Convey("The tasks should be reconciled", func() {
+					So(driver.AssertCalled(t, "ReconcileTasks"), ShouldBeTrue)
+				})
+			})
+
+			Convey("When the scheduler is disconnected", func() {
+				s.Disconnected(nil)
+			})
+
+			Convey("When an offer rescinded", func() {
+				s.OfferRescinded(nil, &mesos.OfferID{})
+			})
+
+			Convey("When a slave was lost", func() {
+				s.SlaveLost(nil, &mesos.SlaveID{})
+			})
+
+			Convey("When an executor was lost", func() {
+				s.ExecutorLost(nil, &mesos.ExecutorID{}, &mesos.SlaveID{}, 2)
+			})
+
+			Convey("When there was an error", func() {
+				s.Error(nil, "Error")
 			})
 		})
+	})
+	Convey("ResourceOffers", t, func() {
+		Convey("Given a scheduler with one scheduled task", func() {
+			s := &eremeticScheduler{
+				tasks:    make(chan string, 1),
+				database: db,
+			}
 
-		Convey("When the scheduler is registered", func() {
+			id := "eremetic-task.9999"
+
+			db.PutTask(&eremetic.Task{ID: id})
+
 			driver := NewMockScheduler()
-			driver.On("ReconcileTasks").Return("ok").Once()
 
-			fid := mesos.FrameworkID{Value: proto.String("1234")}
-			info := mesos.MasterInfo{}
+			Convey("When there are no offers", func() {
+				offers := []*mesos.Offer{}
+				s.ResourceOffers(driver, offers)
 
-			s.Registered(driver, &fid, &info)
-
-			Convey("The tasks should be reconciled", func() {
-				So(driver.AssertCalled(t, "ReconcileTasks"), ShouldBeTrue)
+				Convey("No offers should be declined", func() {
+					So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
+				})
+				Convey("No tasks should be launched", func() {
+					So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
+				})
 			})
-		})
+			Convey("When there are no tasks", func() {
+				offers := []*mesos.Offer{
+					offer("1234", 1.0, 128),
+				}
+				driver.On("DeclineOffer").Return("declined").Once()
 
-		Convey("When the scheduler is reregistered", func() {
-			driver := NewMockScheduler()
-			driver.On("ReconcileTasks").Return("ok").Once()
-			db.Clean()
+				s.ResourceOffers(driver, offers)
 
-			s.Reregistered(driver, &mesos.MasterInfo{})
-
-			Convey("The tasks should be reconciled", func() {
-				So(driver.AssertCalled(t, "ReconcileTasks"), ShouldBeTrue)
+				Convey("The offer should be declined", func() {
+					So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
+				})
+				Convey("No tasks should be launched", func() {
+					So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
+				})
 			})
-		})
+			Convey("When a task is able to launch", func() {
+				offers := []*mesos.Offer{
+					offer("1234", 1.0, 128),
+				}
+				driver.On("LaunchTasks").Return("launched").Once()
+
+				taskID, err := s.ScheduleTask(eremetic.Request{
+					TaskCPUs:    0.5,
+					TaskMem:     22.0,
+					DockerImage: "busybox",
+					Command:     "echo hello",
+				})
+				So(err, ShouldBeNil)
+
+				s.ResourceOffers(driver, offers)
 
-		Convey("When the scheduler is disconnected", func() {
-			s.Disconnected(nil)
-		})
-
-		Convey("When an offer rescinded", func() {
-			s.OfferRescinded(nil, &mesos.OfferID{})
-		})
-
-		Convey("When a slave was lost", func() {
-			s.SlaveLost(nil, &mesos.SlaveID{})
-		})
-
-		Convey("When an executor was lost", func() {
-			s.ExecutorLost(nil, &mesos.ExecutorID{}, &mesos.SlaveID{}, 2)
-		})
-
-		Convey("When there was an error", func() {
-			s.Error(nil, "Error")
-		})
-	})
-	Convey("Given a scheduler with one scheduled task", t, func() {
-		s := &eremeticScheduler{
-			tasks:    make(chan string, 1),
-			database: db,
-		}
-
-		id := "eremetic-task.9999"
-
-		db.PutTask(&eremetic.Task{ID: id})
-
-		driver := NewMockScheduler()
-
-		Convey("When there are no offers", func() {
-			offers := []*mesos.Offer{}
-			s.ResourceOffers(driver, offers)
-
-			Convey("No offers should be declined", func() {
-				So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
-			})
-			Convey("No tasks should be launched", func() {
-				So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
-			})
-		})
-		Convey("When there are no tasks", func() {
-			offers := []*mesos.Offer{
-				offer("1234", 1.0, 128),
-			}
-			driver.On("DeclineOffer").Return("declined").Once()
-
-			s.ResourceOffers(driver, offers)
-
-			Convey("The offer should be declined", func() {
-				So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
-			})
-			Convey("No tasks should be launched", func() {
-				So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
-			})
-		})
-		Convey("When a task is able to launch", func() {
-			offers := []*mesos.Offer{
-				offer("1234", 1.0, 128),
-			}
-			driver.On("LaunchTasks").Return("launched").Once()
-
-			taskID, err := s.ScheduleTask(eremetic.Request{
-				TaskCPUs:    0.5,
-				TaskMem:     22.0,
-				DockerImage: "busybox",
-				Command:     "echo hello",
-			})
-			So(err, ShouldBeNil)
-
-			s.ResourceOffers(driver, offers)
-
-			task, err := db.ReadTask(taskID)
-			So(err, ShouldBeNil)
-
-			Convey("The task should contain the status history", func() {
-				So(task.Status, ShouldHaveLength, 2)
-				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
-				So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_STAGING)
-			})
-			Convey("The offer should not be declined", func() {
-				So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
-			})
-			Convey("The tasks should be launched", func() {
-				So(driver.AssertCalled(t, "LaunchTasks"), ShouldBeTrue)
-			})
-		})
-
-		Convey("When a task unable to launch", func() {
-			offers := []*mesos.Offer{
-				offer("1234", 1.0, 128),
-			}
-			driver.On("DeclineOffer").Return("declined").Once()
-
-			_, err := s.ScheduleTask(eremetic.Request{
-				TaskCPUs:    1.5,
-				TaskMem:     22.0,
-				DockerImage: "busybox",
-				Command:     "echo hello",
-			})
-			So(err, ShouldBeNil)
-
-			s.ResourceOffers(driver, offers)
-
-			Convey("The offer should be declined", func() {
-				So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
-			})
-			Convey("The tasks should not be launched", func() {
-				So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
-			})
-		})
-	})
-	Convey("Given a scheduler with one scheduled task", t, func() {
-		s := &eremeticScheduler{
-			tasks:    make(chan string, 1),
-			database: db,
-		}
-
-		id := "eremetic-task.9999"
-
-		db.PutTask(&eremetic.Task{ID: id})
-
-		Convey("When a running task fails", func() {
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_RUNNING.Enum(),
-			})
-
-			task, err := db.ReadTask(id)
-			So(err, ShouldBeNil)
-
-			So(len(task.Status), ShouldEqual, 1)
-			So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_FAILED.Enum(),
-			})
-
-			task, err = db.ReadTask(id)
-			So(err, ShouldBeNil)
-
-			Convey("The task status history should contain the failed status", func() {
-				So(len(task.Status), ShouldEqual, 2)
-				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
-				So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
-			})
-		})
-
-		Convey("When a task fails immediately", func() {
-			s.tasks = make(chan string, 100)
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_FAILED.Enum(),
-			})
-
-			task, err := db.ReadTask(id)
-			So(err, ShouldBeNil)
-
-			Convey("The task should have a queued status", func() {
-				So(len(task.Status), ShouldEqual, 2)
-				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
-				So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
-			})
-
-			Convey("The task should be published on channel", func() {
-				c := <-s.tasks
-
-				So(c, ShouldEqual, id)
-			})
-		})
-
-		Convey("When a task finishes with a callback specified", func() {
-			cb, ts := callbackReceiver()
-			defer ts.Close()
-
-			id := "eremetic-task.1000"
-
-			db.PutTask(&eremetic.Task{
-				ID:          id,
-				CallbackURI: ts.URL,
-			})
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_FINISHED.Enum(),
-			})
-
-			Convey("The callback data should be available", func() {
-				c := <-cb
-
-				So(c.TaskID, ShouldEqual, id)
-				So(c.Status, ShouldEqual, "TASK_FINISHED")
-			})
-		})
-
-		Convey("When a task fails with a callback specified", func() {
-			cb, ts := callbackReceiver()
-			defer ts.Close()
-
-			id := "eremetic-task.1001"
-
-			db.PutTask(&eremetic.Task{
-				ID:          id,
-				CallbackURI: ts.URL,
-			})
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_RUNNING.Enum(),
-			})
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_FAILED.Enum(),
-			})
-
-			Convey("The callback data should be available", func() {
-				c := <-cb
-
-				So(c.TaskID, ShouldEqual, id)
-				So(c.Status, ShouldEqual, "TASK_FAILED")
-			})
-		})
-
-		Convey("When a task retries with a callback specified", func() {
-			cb, ts := callbackReceiver()
-			defer ts.Close()
-
-			id := "eremetic-task.1002"
-
-			db.PutTask(&eremetic.Task{
-				ID:          id,
-				CallbackURI: ts.URL,
-			})
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_FAILED.Enum(),
-			})
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_RUNNING.Enum(),
-			})
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				State: mesos.TaskState_TASK_FINISHED.Enum(),
-			})
-
-			Convey("The callback data should be available", func() {
-				c := <-cb
-
-				So(c.TaskID, ShouldEqual, id)
-				So(c.Status, ShouldEqual, "TASK_FINISHED")
-			})
-		})
-
-		Convey("When the sandbox is updated", func() {
-			id := "eremetic-task.1003"
-
-			s.StatusUpdate(nil, &mesos.TaskStatus{
-				TaskId: &mesos.TaskID{
-					Value: proto.String(id),
-				},
-				Data:  []byte(`[{"Mounts":[{"Source":"/tmp/mesos/slaves/<agent_id>/frameworks/<framework_id>/executors/<task_id>/runs/<container_id>","Destination":"/mnt/mesos/sandbox","Mode":"","RW":true}]}]`),
-				State: mesos.TaskState_TASK_RUNNING.Enum(),
-			})
-
-			task, err := db.ReadTask(id)
-			So(err, ShouldBeNil)
-
-			Convey("There should be a path to the sandbox", func() {
-				So(task.SandboxPath, ShouldNotBeEmpty)
-			})
-		})
-	})
-	Convey("Given a scheduler with one scheduled task", t, func() {
-		s := &eremeticScheduler{
-			tasks:    make(chan string, 1),
-			database: db,
-		}
-
-		id := "eremetic-task.9999"
-		db.PutTask(&eremetic.Task{ID: id})
-
-		driver := NewMockScheduler()
-		message := `{"message": "this is a message"}`
-
-		Convey("When receiving a framework message from Eremetic", func() {
-			source := "eremetic-executor"
-			executor := mesos.ExecutorID{
-				Value: proto.String(source),
-			}
-			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
-		})
-
-		Convey("When receiving a framework message from an unknown source", func() {
-			source := "other-source"
-			executor := mesos.ExecutorID{
-				Value: proto.String(source),
-			}
-			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
-		})
-
-		Convey("When the framework message format is invalid", func() {
-			source := "eremetic-executor"
-			executor := mesos.ExecutorID{
-				Value: proto.String(source),
-			}
-			s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, "not a json")
-		})
-	})
-	Convey("Given a scheduler with no scheduled tasks", t, func() {
-		scheduler := &eremeticScheduler{
-			tasks:    make(chan string, 1),
-			database: db,
-		}
-
-		Convey("When scheduling a task", func() {
-			request := eremetic.Request{
-				TaskCPUs:    0.5,
-				TaskMem:     22.0,
-				DockerImage: "busybox",
-				Command:     "echo hello",
-			}
-
-			taskID, err := scheduler.ScheduleTask(request)
-			So(err, ShouldBeNil)
-
-			Convey("It should put a task id on the channel", func() {
-				c := <-scheduler.tasks
-				So(c, ShouldEqual, taskID)
-			})
-
-			Convey("The task should be present in the database", func() {
 				task, err := db.ReadTask(taskID)
 				So(err, ShouldBeNil)
 
-				So(task.TaskCPUs, ShouldEqual, request.TaskCPUs)
-				So(task.TaskMem, ShouldEqual, request.TaskMem)
-				So(task.Command, ShouldEqual, request.Command)
-				So(task.User, ShouldEqual, "root")
-				So(task.Environment, ShouldBeEmpty)
-				So(task.Image, ShouldEqual, request.DockerImage)
-				So(task.ID, ShouldStartWith, "eremetic-task.")
+				Convey("The task should contain the status history", func() {
+					So(task.Status, ShouldHaveLength, 2)
+					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
+					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_STAGING)
+				})
+				Convey("The offer should not be declined", func() {
+					So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
+				})
+				Convey("The tasks should be launched", func() {
+					So(driver.AssertCalled(t, "LaunchTasks"), ShouldBeTrue)
+				})
 			})
-		})
 
-		Convey("When scheduling a task and the queue is full", func() {
-			scheduler.tasks <- "dummy"
+			Convey("When a task unable to launch", func() {
+				offers := []*mesos.Offer{
+					offer("1234", 1.0, 128),
+				}
+				driver.On("DeclineOffer").Return("declined").Once()
 
-			request := eremetic.Request{
-				TaskCPUs:    0.5,
-				TaskMem:     22.0,
-				DockerImage: "busybox",
-				Command:     "echo hello",
-			}
+				_, err := s.ScheduleTask(eremetic.Request{
+					TaskCPUs:    1.5,
+					TaskMem:     22.0,
+					DockerImage: "busybox",
+					Command:     "echo hello",
+				})
+				So(err, ShouldBeNil)
 
-			_, err := scheduler.ScheduleTask(request)
+				s.ResourceOffers(driver, offers)
 
-			Convey("It should return an error", func() {
-				So(err, ShouldNotBeNil)
+				Convey("The offer should be declined", func() {
+					So(driver.AssertCalled(t, "DeclineOffer"), ShouldBeTrue)
+				})
+				Convey("The tasks should not be launched", func() {
+					So(driver.AssertNotCalled(t, "LaunchTasks"), ShouldBeTrue)
+				})
 			})
 		})
 	})
-	Convey("Given a scheduler with no scheduled tasks", t, func() {
-		scheduler := &eremeticScheduler{
-			tasks:    make(chan string, 100),
-			database: db,
-		}
+	Convey("StatusUpdate", t, func() {
+		Convey("Given a scheduler with one scheduled task", func() {
+			s := &eremeticScheduler{
+				tasks:    make(chan string, 1),
+				database: db,
+			}
 
-		Convey("When generating a random string", func() {
-			str := nextID(scheduler)
+			id := "eremetic-task.9999"
 
-			Convey("The string should not be empty", func() {
-				So(str, ShouldNotBeEmpty)
+			db.PutTask(&eremetic.Task{ID: id})
+
+			Convey("When a running task fails", func() {
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_RUNNING.Enum(),
+				})
+
+				task, err := db.ReadTask(id)
+				So(err, ShouldBeNil)
+
+				So(len(task.Status), ShouldEqual, 1)
+				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_FAILED.Enum(),
+				})
+
+				task, err = db.ReadTask(id)
+				So(err, ShouldBeNil)
+
+				Convey("The task status history should contain the failed status", func() {
+					So(len(task.Status), ShouldEqual, 2)
+					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
+					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
+				})
+			})
+
+			Convey("When a task fails immediately", func() {
+				s.tasks = make(chan string, 100)
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_FAILED.Enum(),
+				})
+
+				task, err := db.ReadTask(id)
+				So(err, ShouldBeNil)
+
+				Convey("The task should have a queued status", func() {
+					So(len(task.Status), ShouldEqual, 2)
+					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
+					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
+				})
+
+				Convey("The task should be published on channel", func() {
+					c := <-s.tasks
+
+					So(c, ShouldEqual, id)
+				})
+			})
+
+			Convey("When a task finishes with a callback specified", func() {
+				cb, ts := callbackReceiver()
+				defer ts.Close()
+
+				id := "eremetic-task.1000"
+
+				db.PutTask(&eremetic.Task{
+					ID:          id,
+					CallbackURI: ts.URL,
+				})
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_FINISHED.Enum(),
+				})
+
+				Convey("The callback data should be available", func() {
+					c := <-cb
+
+					So(c.TaskID, ShouldEqual, id)
+					So(c.Status, ShouldEqual, "TASK_FINISHED")
+				})
+			})
+
+			Convey("When a task fails with a callback specified", func() {
+				cb, ts := callbackReceiver()
+				defer ts.Close()
+
+				id := "eremetic-task.1001"
+
+				db.PutTask(&eremetic.Task{
+					ID:          id,
+					CallbackURI: ts.URL,
+				})
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_RUNNING.Enum(),
+				})
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_FAILED.Enum(),
+				})
+
+				Convey("The callback data should be available", func() {
+					c := <-cb
+
+					So(c.TaskID, ShouldEqual, id)
+					So(c.Status, ShouldEqual, "TASK_FAILED")
+				})
+			})
+
+			Convey("When a task retries with a callback specified", func() {
+				cb, ts := callbackReceiver()
+				defer ts.Close()
+
+				id := "eremetic-task.1002"
+
+				db.PutTask(&eremetic.Task{
+					ID:          id,
+					CallbackURI: ts.URL,
+				})
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_FAILED.Enum(),
+				})
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_RUNNING.Enum(),
+				})
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					State: mesos.TaskState_TASK_FINISHED.Enum(),
+				})
+
+				Convey("The callback data should be available", func() {
+					c := <-cb
+
+					So(c.TaskID, ShouldEqual, id)
+					So(c.Status, ShouldEqual, "TASK_FINISHED")
+				})
+			})
+
+			Convey("When the sandbox is updated", func() {
+				id := "eremetic-task.1003"
+
+				s.StatusUpdate(nil, &mesos.TaskStatus{
+					TaskId: &mesos.TaskID{
+						Value: proto.String(id),
+					},
+					Data:  []byte(`[{"Mounts":[{"Source":"/tmp/mesos/slaves/<agent_id>/frameworks/<framework_id>/executors/<task_id>/runs/<container_id>","Destination":"/mnt/mesos/sandbox","Mode":"","RW":true}]}]`),
+					State: mesos.TaskState_TASK_RUNNING.Enum(),
+				})
+
+				task, err := db.ReadTask(id)
+				So(err, ShouldBeNil)
+
+				Convey("There should be a path to the sandbox", func() {
+					So(task.SandboxPath, ShouldNotBeEmpty)
+				})
+			})
+		})
+	})
+	Convey("FrameworkMessage", t, func() {
+		Convey("Given a scheduler with one scheduled task", func() {
+			s := &eremeticScheduler{
+				tasks:    make(chan string, 1),
+				database: db,
+			}
+
+			id := "eremetic-task.9999"
+			db.PutTask(&eremetic.Task{ID: id})
+
+			driver := NewMockScheduler()
+			message := `{"message": "this is a message"}`
+
+			Convey("When receiving a framework message from Eremetic", func() {
+				source := "eremetic-executor"
+				executor := mesos.ExecutorID{
+					Value: proto.String(source),
+				}
+				s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
+			})
+
+			Convey("When receiving a framework message from an unknown source", func() {
+				source := "other-source"
+				executor := mesos.ExecutorID{
+					Value: proto.String(source),
+				}
+				s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, message)
+			})
+
+			Convey("When the framework message format is invalid", func() {
+				source := "eremetic-executor"
+				executor := mesos.ExecutorID{
+					Value: proto.String(source),
+				}
+				s.FrameworkMessage(driver, &executor, &mesos.SlaveID{}, "not a json")
+			})
+		})
+	})
+	Convey("ScheduleTask", t, func() {
+		Convey("Given a scheduler with no scheduled tasks", func() {
+			scheduler := &eremeticScheduler{
+				tasks:    make(chan string, 1),
+				database: db,
+			}
+
+			Convey("When scheduling a task", func() {
+				request := eremetic.Request{
+					TaskCPUs:    0.5,
+					TaskMem:     22.0,
+					DockerImage: "busybox",
+					Command:     "echo hello",
+				}
+
+				taskID, err := scheduler.ScheduleTask(request)
+				So(err, ShouldBeNil)
+
+				Convey("It should put a task id on the channel", func() {
+					c := <-scheduler.tasks
+					So(c, ShouldEqual, taskID)
+				})
+
+				Convey("The task should be present in the database", func() {
+					task, err := db.ReadTask(taskID)
+					So(err, ShouldBeNil)
+
+					So(task.TaskCPUs, ShouldEqual, request.TaskCPUs)
+					So(task.TaskMem, ShouldEqual, request.TaskMem)
+					So(task.Command, ShouldEqual, request.Command)
+					So(task.User, ShouldEqual, "root")
+					So(task.Environment, ShouldBeEmpty)
+					So(task.Image, ShouldEqual, request.DockerImage)
+					So(task.ID, ShouldStartWith, "eremetic-task.")
+				})
+			})
+
+			Convey("When scheduling a task and the queue is full", func() {
+				scheduler.tasks <- "dummy"
+
+				request := eremetic.Request{
+					TaskCPUs:    0.5,
+					TaskMem:     22.0,
+					DockerImage: "busybox",
+					Command:     "echo hello",
+				}
+
+				_, err := scheduler.ScheduleTask(request)
+
+				Convey("It should return an error", func() {
+					So(err, ShouldNotBeNil)
+				})
+			})
+		})
+	})
+	Convey("nextID", t, func() {
+		Convey("Given a scheduler with no scheduled tasks", func() {
+			scheduler := &eremeticScheduler{
+				tasks:    make(chan string, 100),
+				database: db,
+			}
+
+			Convey("When generating a random string", func() {
+				str := nextID(scheduler)
+
+				Convey("The string should not be empty", func() {
+					So(str, ShouldNotBeEmpty)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
The scheduler test is quite massive and personally I had some difficulty of keeping track of the state in each test case. Splitting the test (hopefully) makes it easier to follow.

Also, since Eremetic is using GoConvey for tests, which AFAIK made for BDD-style tests, I took the liberty of reformulating the test cases in the form of Given, When, Then.

The actual tests haven't been modified though. Let me know if you think that's the case or whether my test descriptions are accurate or not.