### PR TITLE
Add host ports to task environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ JSON format:
       "host_path": "/var/run/docker.sock"
     }
   ],
-  // Array of Objects, ports to forward to the container
+  // Array of Objects, ports to forward to the container.
+  // Assigned host ports are available as environment variables (e.g. PORT0, PORT1 and so on with PORT being an alias for PORT0).
   "ports": [
     {
       "container_port": 80,

--- a/cmd/hermit/main.go
+++ b/cmd/hermit/main.go
@@ -82,6 +82,7 @@ type runCommand struct {
 	CPU    float64
 	Memory float64
 	Image  string
+	Port   uint
 
 	flags  *flag.FlagSet
 	client *client.Client
@@ -98,6 +99,7 @@ func (cmd *runCommand) Parse(args []string) {
 	cmd.flags.Float64Var(&cmd.CPU, "cpu", 0.1, "CPU shares to give to the task")
 	cmd.flags.Float64Var(&cmd.Memory, "mem", 128, "Memory in MB to give to the task")
 	cmd.flags.StringVar(&cmd.Image, "image", "busybox", "Image to use")
+	cmd.flags.UintVar(&cmd.Port, "port", 0, "Port for task to listen on")
 	cmd.flags.Parse(args)
 }
 
@@ -115,6 +117,12 @@ func (cmd *runCommand) Run() {
 		DockerImage: cmd.Image,
 		TaskCPUs:    cmd.CPU,
 		TaskMem:     cmd.Memory,
+		Ports: []eremetic.Port{
+			{
+				ContainerPort: uint32(cmd.Port),
+				Protocol:      "tcp",
+			},
+		},
 	}
 
 	if err := cmd.client.AddTask(r); err != nil {

--- a/mesos/task_test.go
+++ b/mesos/task_test.go
@@ -117,6 +117,22 @@ func TestTask(t *testing.T) {
 			expected_range := mesosutil.NewValueRange(31000, 31001)
 			So(taskInfo.GetResources()[2].GetRanges().GetRange()[0].GetBegin(), ShouldEqual, expected_range.GetBegin())
 			So(taskInfo.GetResources()[2].GetRanges().GetRange()[0].GetEnd(), ShouldEqual, expected_range.GetEnd())
+
+			vars := taskInfo.GetCommand().GetEnvironment().GetVariables()
+
+			var foundPortVar, foundPort0Var bool
+			for _, v := range vars {
+				switch v.GetName() {
+				case "PORT":
+					So(v.GetValue(), ShouldEqual, "31000")
+					foundPortVar = true
+				case "PORT0":
+					So(v.GetValue(), ShouldEqual, "31000")
+					foundPort0Var = true
+				}
+			}
+			So(foundPortVar, ShouldBeTrue)
+			So(foundPort0Var, ShouldBeTrue)
 		})
 
 		Convey("Given archive to fetch", func() {


### PR DESCRIPTION
Adds the assigned host ports to the environment to allow tasks to announce where to find them.