### PR TITLE
Add Args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ JSON format:
   "force_pull_image": false,
   // String, command to run in the docker container
   "command": "echo date",
+  // Array of Strings, arguements to pass to the docker container entrypoint
+  "args": ["+%s"],
   // Array of Objects, volumes to mount in the container
   "volumes": [
     {

--- a/mesos/task.go
+++ b/mesos/task.go
@@ -172,9 +172,11 @@ func buildCommandInfo(task eremetic.Task, env *mesosproto.Environment) *mesospro
 	}
 
 	if task.Command != "" {
+		commandInfo.Shell = proto.Bool(true)
 		commandInfo.Value = &task.Command
 	} else {
 		commandInfo.Shell = proto.Bool(false)
+		commandInfo.Arguments = task.Args
 	}
 
 	return commandInfo

--- a/misc/swagger.yaml
+++ b/misc/swagger.yaml
@@ -97,6 +97,9 @@ definitions:
       command:
         type: string
         description: Command to run in the docker container
+      args:
+        type: array 
+        description: arguements to pass to the docker container entrypoint
       task_cpu:
         type: number
         description: Fractions of a CPU to request

--- a/task.go
+++ b/task.go
@@ -73,6 +73,7 @@ type Task struct {
 	TaskCPUs          float64           `json:"task_cpus"`
 	TaskMem           float64           `json:"task_mem"`
 	Command           string            `json:"command"`
+	Args              []string          `json:"args"`
 	User              string            `json:"user"`
 	Environment       map[string]string `json:"env"`
 	MaskedEnvironment map[string]string `json:"masked_env"`
@@ -132,6 +133,7 @@ type Request struct {
 	TaskMem           float64           `json:"task_mem"`
 	DockerImage       string            `json:"docker_image"`
 	Command           string            `json:"command"`
+	Args              []string          `json:"args"`
 	Volumes           []Volume          `json:"volumes"`
 	Ports             []Port            `json:"ports"`
 	Environment       map[string]string `json:"env"`
@@ -160,6 +162,7 @@ func NewTask(request Request, name string) (Task, error) {
 		Name:              name,
 		Status:            status,
 		Command:           request.Command,
+		Args:              request.Args,
 		User:              "root",
 		Environment:       request.Environment,
 		MaskedEnvironment: request.MaskedEnvironment,


### PR DESCRIPTION
This would be a breaking change as `command` will now run with `sh -c` instead of the default entrypoint. Args will call the default entry point.

Should fix #100