### PR TITLE
Fix linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ test-server: ${TOOLS}
 test-docker:
 	$(DOCKER_GOLANG_RUN_CMD) "make test"
 
+vet:
+	go vet ${PACKAGES}
+
+lint:
+	go list ./... | grep -v /vendor/ | grep -v assets | xargs -L1 golint -set_exit_status
+
 server/assets/assets.go: server/generate.go ${STATIC}
 	go generate github.com/klarna/eremetic/server
 

--- a/boltdb/boltdb.go
+++ b/boltdb/boltdb.go
@@ -33,6 +33,7 @@ func (b defaultConnector) Open(file string) (connection, error) {
 	return bolt.Open(file, 0600, nil)
 }
 
+// TaskDB is a boltdb implementation of the task database.
 type TaskDB struct {
 	conn connection
 }

--- a/boltdb/boltdb_test.go
+++ b/boltdb/boltdb_test.go
@@ -38,7 +38,7 @@ func TestBoltDatabase(t *testing.T) {
 
 	status := []eremetic.Status{
 		eremetic.Status{
-			Status: eremetic.TaskState_TASK_RUNNING,
+			Status: eremetic.TaskRunning,
 			Time:   time.Now().Unix(),
 		},
 	}
@@ -106,7 +106,7 @@ func TestBoltDatabase(t *testing.T) {
 			TaskMem:           15.3,
 			Name:              "request Name",
 			Status:            status,
-			FrameworkId:       "1234",
+			FrameworkID:       "1234",
 			Command:           "echo date",
 			User:              "root",
 			Image:             "busybox",
@@ -138,7 +138,7 @@ func TestBoltDatabase(t *testing.T) {
 			TaskMem:           15.3,
 			Name:              "request Name",
 			Status:            status,
-			FrameworkId:       "1234",
+			FrameworkID:       "1234",
 			Command:           "echo date",
 			User:              "root",
 			Image:             "busybox",
@@ -166,15 +166,15 @@ func TestBoltDatabase(t *testing.T) {
 			ID: "1234",
 			Status: []eremetic.Status{
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_STAGING,
+					Status: eremetic.TaskStaging,
 					Time:   time.Now().Unix(),
 				},
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_RUNNING,
+					Status: eremetic.TaskRunning,
 					Time:   time.Now().Unix(),
 				},
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_FINISHED,
+					Status: eremetic.TaskFinished,
 					Time:   time.Now().Unix(),
 				},
 			},
@@ -185,11 +185,11 @@ func TestBoltDatabase(t *testing.T) {
 			ID: "2345",
 			Status: []eremetic.Status{
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_STAGING,
+					Status: eremetic.TaskStaging,
 					Time:   time.Now().Unix(),
 				},
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_RUNNING,
+					Status: eremetic.TaskRunning,
 					Time:   time.Now().Unix(),
 				},
 			},
@@ -212,15 +212,15 @@ func TestBoltDatabase(t *testing.T) {
 			ID: "1234",
 			Status: []eremetic.Status{
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_STAGING,
+					Status: eremetic.TaskStaging,
 					Time:   time.Now().Unix(),
 				},
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_RUNNING,
+					Status: eremetic.TaskRunning,
 					Time:   time.Now().Unix(),
 				},
 				eremetic.Status{
-					Status: eremetic.TaskState_TASK_FINISHED,
+					Status: eremetic.TaskFinished,
 					Time:   time.Now().Unix(),
 				},
 			},

--- a/callback.go
+++ b/callback.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+// CallbackData holds information about the status update.
 type CallbackData struct {
 	Time   int64  `json:"time"`
 	Status string `json:"status"`

--- a/callback_test.go
+++ b/callback_test.go
@@ -52,7 +52,7 @@ func TestCallback(t *testing.T) {
 		Convey("When notifying with one status", func() {
 			task.CallbackURI = ts.URL
 			task.Status = []Status{
-				{Time: 0, Status: TaskState_TASK_STAGING},
+				{Time: 0, Status: TaskStaging},
 			}
 
 			NotifyCallback(&task)
@@ -69,9 +69,9 @@ func TestCallback(t *testing.T) {
 		Convey("When notifying with many statuses", func() {
 			task.CallbackURI = ts.URL
 			task.Status = []Status{
-				{Time: 0, Status: TaskState_TASK_STAGING},
-				{Time: 1, Status: TaskState_TASK_RUNNING},
-				{Time: 2, Status: TaskState_TASK_FINISHED},
+				{Time: 0, Status: TaskStaging},
+				{Time: 1, Status: TaskRunning},
+				{Time: 2, Status: TaskFinished},
 			}
 
 			NotifyCallback(&task)

--- a/client/client.go
+++ b/client/client.go
@@ -10,11 +10,13 @@ import (
 	"github.com/klarna/eremetic"
 )
 
+// Client is used for communicating with an Eremetic server.
 type Client struct {
 	httpClient *http.Client
 	endpoint   string
 }
 
+// New returns a new instance of a Client.
 func New(endpoint string, client *http.Client) (*Client, error) {
 	return &Client{
 		httpClient: client,
@@ -22,6 +24,7 @@ func New(endpoint string, client *http.Client) (*Client, error) {
 	}, nil
 }
 
+// AddTask sends a request for a new task to be scheduled.
 func (c *Client) AddTask(r eremetic.Request) error {
 	var buf bytes.Buffer
 
@@ -43,6 +46,7 @@ func (c *Client) AddTask(r eremetic.Request) error {
 	return nil
 }
 
+// Task returns a task with a given ID.
 func (c *Client) Task(id string) (*eremetic.Task, error) {
 	req, err := http.NewRequest("GET", c.endpoint+"/task/"+id, nil)
 	if err != nil {
@@ -64,6 +68,7 @@ func (c *Client) Task(id string) (*eremetic.Task, error) {
 	return &task, nil
 }
 
+// Tasks returns all current tasks.
 func (c *Client) Tasks() ([]eremetic.Task, error) {
 	req, err := http.NewRequest("GET", c.endpoint+"/task", nil)
 	if err != nil {
@@ -85,6 +90,7 @@ func (c *Client) Tasks() ([]eremetic.Task, error) {
 	return tasks, nil
 }
 
+// Sandbox returns a sandbox resource for a given task.
 func (c *Client) Sandbox(taskID, file string) ([]byte, error) {
 	u := fmt.Sprintf("%s/task/%s/%s", c.endpoint, taskID, file)
 	req, err := http.NewRequest("GET", u, nil)
@@ -105,6 +111,7 @@ func (c *Client) Sandbox(taskID, file string) ([]byte, error) {
 	return b, nil
 }
 
+// Version returns the version of the Eremetic server.
 func (c *Client) Version() (string, error) {
 	u := fmt.Sprintf("%s/version", c.endpoint)
 	req, err := http.NewRequest("GET", u, nil)

--- a/cmd/eremetic/eremetic.go
+++ b/cmd/eremetic/eremetic.go
@@ -38,15 +38,6 @@ func setupLogging(logFormat, logLevel string) {
 	logrus.SetLevel(level)
 }
 
-func setupMetrics() {
-	prometheus.MustRegister(mesos.TasksCreated)
-	prometheus.MustRegister(mesos.TasksLaunched)
-	prometheus.MustRegister(mesos.TasksTerminated)
-	prometheus.MustRegister(mesos.TasksDelayed)
-	prometheus.MustRegister(mesos.TasksRunning)
-	prometheus.MustRegister(mesos.QueueSize)
-}
-
 func getSchedulerSettings(config *config.Config) *mesos.Settings {
 	return &mesos.Settings{
 		MaxQueueSize:     config.QueueSize,
@@ -70,7 +61,8 @@ func main() {
 	config := setup()
 
 	setupLogging(config.LogFormat, config.LogLevel)
-	setupMetrics()
+
+	mesos.RegisterMetrics(prometheus.DefaultRegisterer)
 
 	db, err := NewDB(config.DatabaseDriver, config.DatabasePath)
 	if err != nil {

--- a/cmd/hermit/main.go
+++ b/cmd/hermit/main.go
@@ -379,6 +379,7 @@ func (cmd *versionCommand) Run() {
 	fmt.Printf(" Version: %s", b)
 }
 
+// ByLastUpdated sorts tasks based by when they were last updated.
 type ByLastUpdated []eremetic.Task
 
 func (t ByLastUpdated) Len() int           { return len(t) }
@@ -391,23 +392,23 @@ func currentStatus(statuses []eremetic.Status) string {
 	}
 
 	switch statuses[len(statuses)-1].Status {
-	case eremetic.TaskState_TASK_STAGING:
+	case eremetic.TaskStaging:
 		return "staging"
-	case eremetic.TaskState_TASK_STARTING:
+	case eremetic.TaskStarting:
 		return "starting"
-	case eremetic.TaskState_TASK_RUNNING:
+	case eremetic.TaskRunning:
 		return "running"
-	case eremetic.TaskState_TASK_FINISHED:
+	case eremetic.TaskFinished:
 		return "finished"
-	case eremetic.TaskState_TASK_FAILED:
+	case eremetic.TaskFailed:
 		return "failed"
-	case eremetic.TaskState_TASK_KILLED:
+	case eremetic.TaskKilled:
 		return "killed"
-	case eremetic.TaskState_TASK_LOST:
+	case eremetic.TaskLost:
 		return "lost"
-	case eremetic.TaskState_TASK_ERROR:
+	case eremetic.TaskError:
 		return "error"
-	case eremetic.TaskState_TASK_QUEUED:
+	case eremetic.TaskQueued:
 		return "queued"
 	}
 

--- a/database.go
+++ b/database.go
@@ -6,14 +6,17 @@ import (
 	"sync"
 )
 
+// Masking is the string used for masking environment variables.
 const Masking = "*******"
 
+// ApplyMask replaces masked environment variables with a masking string.
 func ApplyMask(task *Task) {
 	for k := range task.MaskedEnvironment {
 		task.MaskedEnvironment[k] = Masking
 	}
 }
 
+// Encode encodes a task into a JSON byte array.
 func Encode(task *Task) ([]byte, error) {
 	encoded, err := json.Marshal(task)
 	return []byte(encoded), err
@@ -29,26 +32,31 @@ type TaskDB interface {
 	ListNonTerminalTasks() ([]*Task, error)
 }
 
+// DefaultTaskDB is a in-memory implementation of TaskDB.
 type DefaultTaskDB struct {
 	mtx   sync.RWMutex
 	tasks map[string]*Task
 }
 
+// NewDefaultTaskDB returns a new instance of TaskDB.
 func NewDefaultTaskDB() *DefaultTaskDB {
 	return &DefaultTaskDB{
 		tasks: make(map[string]*Task),
 	}
 }
 
+// Clean removes all tasks from the database.
 func (db *DefaultTaskDB) Clean() error {
 	db.tasks = make(map[string]*Task)
 	return nil
 }
 
+// Close closes the connection to the database.
 func (db *DefaultTaskDB) Close() {
 	return
 }
 
+// PutTask adds a new task to the database.
 func (db *DefaultTaskDB) PutTask(task *Task) error {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
@@ -56,6 +64,7 @@ func (db *DefaultTaskDB) PutTask(task *Task) error {
 	return nil
 }
 
+// ReadTask returns a task with a given id, or an error if not found.
 func (db *DefaultTaskDB) ReadTask(id string) (Task, error) {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()
@@ -63,18 +72,20 @@ func (db *DefaultTaskDB) ReadTask(id string) (Task, error) {
 		ApplyMask(task)
 		return *task, nil
 	}
-	return Task{}, errors.New("unknown cargo")
+	return Task{}, errors.New("unknown task")
 }
 
+// ReadUnmaskedTask returns a task with all its environment variables unmasked.
 func (db *DefaultTaskDB) ReadUnmaskedTask(id string) (Task, error) {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()
 	if task, ok := db.tasks[id]; ok {
 		return *task, nil
 	}
-	return Task{}, errors.New("unknown cargo")
+	return Task{}, errors.New("unknown task")
 }
 
+// ListNonTerminalTasks returns all non-terminal tasks.
 func (db *DefaultTaskDB) ListNonTerminalTasks() ([]*Task, error) {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()

--- a/mesos/extractor.go
+++ b/mesos/extractor.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/mesos/mesos-go/mesosproto"
 )
 
 type mounts struct {
@@ -18,17 +17,15 @@ type dockerMounts struct {
 	RW          bool   `json:"RW"`
 }
 
-func extractSandboxPath(status *mesosproto.TaskStatus) (string, error) {
+func extractSandboxPath(statusData []byte) (string, error) {
 	var mounts []mounts
 
-	if len(status.Data) == 0 {
+	if len(statusData) == 0 {
 		logrus.Debug("No Data in task status.")
 		return "", nil
 	}
 
-	err := json.Unmarshal(status.Data, &mounts)
-
-	if err != nil {
+	if err := json.Unmarshal(statusData, &mounts); err != nil {
 		logrus.WithError(err).Error("Task status data contained invalid JSON.")
 		return "", err
 	}

--- a/mesos/extractor_test.go
+++ b/mesos/extractor_test.go
@@ -3,13 +3,11 @@ package mesos
 import (
 	"testing"
 
-	"github.com/mesos/mesos-go/mesosproto"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func mockStatusWithSandbox() *mesosproto.TaskStatus {
-	return &mesosproto.TaskStatus{
-		Data: []byte(`[
+func mockStatusWithSandbox() []byte {
+	return []byte(`[
                     {
                       "Mounts": [
                         {
@@ -20,13 +18,11 @@ func mockStatusWithSandbox() *mesosproto.TaskStatus {
                         }
                       ]
                     }
-                  ]`),
-	}
+                  ]`)
 }
 
-func mockStatusWithoutSandbox() *mesosproto.TaskStatus {
-	return &mesosproto.TaskStatus{
-		Data: []byte(`[
+func mockStatusWithoutSandbox() []byte {
+	return []byte(`[
                     {
                       "Mounts": [
                         {
@@ -37,18 +33,15 @@ func mockStatusWithoutSandbox() *mesosproto.TaskStatus {
                         }
                       ]
                     }
-                  ]`),
-	}
+                  ]`)
 }
 
-func mockStatusNoMounts() *mesosproto.TaskStatus {
-	return &mesosproto.TaskStatus{
-		Data: []byte(`[
+func mockStatusNoMounts() []byte {
+	return []byte(`[
                     {
                       "Mounts": []
                     }
-                  ]`),
-	}
+                  ]`)
 }
 
 func TestExtractor(t *testing.T) {
@@ -75,7 +68,7 @@ func TestExtractor(t *testing.T) {
 		})
 
 		Convey("Empty data", func() {
-			sandbox, err := extractSandboxPath(&mesosproto.TaskStatus{Data: []byte("")})
+			sandbox, err := extractSandboxPath([]byte(""))
 			So(sandbox, ShouldBeEmpty)
 			So(err, ShouldBeNil)
 		})

--- a/mesos/match.go
+++ b/mesos/match.go
@@ -44,11 +44,11 @@ func (m *resourceMatcher) Description() string {
 	return fmt.Sprintf("%f of scalar resource %s", m.value, m.name)
 }
 
-func CPUAvailable(v float64) ogle.Matcher {
+func cpuAvailable(v float64) ogle.Matcher {
 	return &resourceMatcher{"cpus", v}
 }
 
-func MemoryAvailable(v float64) ogle.Matcher {
+func memoryAvailable(v float64) ogle.Matcher {
 	return &resourceMatcher{"mem", v}
 }
 
@@ -75,7 +75,7 @@ func (m *attributeMatcher) Description() string {
 	)
 }
 
-func AttributeMatch(slaveConstraints []eremetic.SlaveConstraint) ogle.Matcher {
+func attributeMatch(slaveConstraints []eremetic.SlaveConstraint) ogle.Matcher {
 	var submatchers []ogle.Matcher
 	for _, constraint := range slaveConstraints {
 		submatchers = append(submatchers, &attributeMatcher{constraint})
@@ -85,9 +85,9 @@ func AttributeMatch(slaveConstraints []eremetic.SlaveConstraint) ogle.Matcher {
 
 func createMatcher(task eremetic.Task) ogle.Matcher {
 	return ogle.AllOf(
-		CPUAvailable(task.TaskCPUs),
-		MemoryAvailable(task.TaskMem),
-		AttributeMatch(task.SlaveConstraints),
+		cpuAvailable(task.TaskCPUs),
+		memoryAvailable(task.TaskMem),
+		attributeMatch(task.SlaveConstraints),
 	)
 }
 

--- a/mesos/match_test.go
+++ b/mesos/match_test.go
@@ -61,13 +61,13 @@ func TestMatch(t *testing.T) {
 
 	Convey("CPUAvailable", t, func() {
 		Convey("Above", func() {
-			m := CPUAvailable(0.4)
+			m := cpuAvailable(0.4)
 			err := m.Matches(offerA)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("Below", func() {
-			m := CPUAvailable(0.8)
+			m := cpuAvailable(0.8)
 			err := m.Matches(offerA)
 			So(err, ShouldNotBeNil)
 		})
@@ -76,13 +76,13 @@ func TestMatch(t *testing.T) {
 	Convey("MemoryAvailable", t, func() {
 		Convey("Above", func() {
 
-			m := MemoryAvailable(128.0)
+			m := memoryAvailable(128.0)
 			err := m.Matches(offerA)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("Below", func() {
-			m := MemoryAvailable(256.0)
+			m := memoryAvailable(256.0)
 			err := m.Matches(offerA)
 			So(err, ShouldNotBeNil)
 		})
@@ -90,7 +90,7 @@ func TestMatch(t *testing.T) {
 
 	Convey("AttributeMatch", t, func() {
 		Convey("Does match", func() {
-			m := AttributeMatch([]eremetic.SlaveConstraint{
+			m := attributeMatch([]eremetic.SlaveConstraint{
 				eremetic.SlaveConstraint{
 					AttributeName:  "node_name",
 					AttributeValue: "node1",
@@ -100,7 +100,7 @@ func TestMatch(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 		Convey("Does not match", func() {
-			m := AttributeMatch([]eremetic.SlaveConstraint{
+			m := attributeMatch([]eremetic.SlaveConstraint{
 				eremetic.SlaveConstraint{
 					AttributeName:  "node_name",
 					AttributeValue: "node2",

--- a/mesos/reconcile.go
+++ b/mesos/reconcile.go
@@ -15,16 +15,16 @@ var (
 	maxReconciliationDelay = 120
 )
 
-type Reconcile struct {
+type reconciler struct {
 	cancel chan struct{}
 	done   chan struct{}
 }
 
-func (r *Reconcile) Cancel() {
+func (r *reconciler) Cancel() {
 	close(r.cancel)
 }
 
-func ReconcileTasks(driver mesossched.SchedulerDriver, database eremetic.TaskDB) *Reconcile {
+func reconcileTasks(driver mesossched.SchedulerDriver, database eremetic.TaskDB) *reconciler {
 	cancel := make(chan struct{})
 	done := make(chan struct{})
 
@@ -72,7 +72,7 @@ func ReconcileTasks(driver mesossched.SchedulerDriver, database eremetic.TaskDB)
 						statuses = append(statuses, &mesosproto.TaskStatus{
 							State:   mesosproto.TaskState_TASK_STAGING.Enum(),
 							TaskId:  &mesosproto.TaskID{Value: proto.String(t.ID)},
-							SlaveId: &mesosproto.SlaveID{Value: proto.String(t.SlaveId)},
+							SlaveId: &mesosproto.SlaveID{Value: proto.String(t.SlaveID)},
 						})
 					}
 					logrus.WithField("reconciliation_request_count", c).Debug("Sending reconciliation request")
@@ -94,7 +94,7 @@ func ReconcileTasks(driver mesossched.SchedulerDriver, database eremetic.TaskDB)
 		close(done)
 	}()
 
-	return &Reconcile{
+	return &reconciler{
 		cancel: cancel,
 		done:   done,
 	}

--- a/mesos/reconcile_test.go
+++ b/mesos/reconcile_test.go
@@ -18,7 +18,7 @@ func TestReconcile(t *testing.T) {
 	Convey("ReconcileTasks", t, func() {
 		Convey("Finishes when there are no tasks", func() {
 			driver := NewMockScheduler()
-			r := ReconcileTasks(driver, db)
+			r := reconcileTasks(driver, db)
 
 			select {
 			case <-r.done:
@@ -35,7 +35,7 @@ func TestReconcile(t *testing.T) {
 					panic("mock error")
 				}
 				t.UpdateStatus(eremetic.Status{
-					Status: eremetic.TaskState_TASK_RUNNING,
+					Status: eremetic.TaskRunning,
 					Time:   time.Now().Unix() + 1,
 				})
 				db.PutTask(&t)
@@ -45,13 +45,13 @@ func TestReconcile(t *testing.T) {
 				ID: "1234",
 				Status: []eremetic.Status{
 					eremetic.Status{
-						Status: eremetic.TaskState_TASK_STAGING,
+						Status: eremetic.TaskStaging,
 						Time:   time.Now().Unix(),
 					},
 				},
 			})
 
-			r := ReconcileTasks(driver, db)
+			r := reconcileTasks(driver, db)
 
 			select {
 			case <-r.done:
@@ -67,13 +67,13 @@ func TestReconcile(t *testing.T) {
 				ID: "1234",
 				Status: []eremetic.Status{
 					eremetic.Status{
-						Status: eremetic.TaskState_TASK_STAGING,
+						Status: eremetic.TaskStaging,
 						Time:   time.Now().Unix(),
 					},
 				},
 			})
 
-			r := ReconcileTasks(driver, db)
+			r := reconcileTasks(driver, db)
 			r.Cancel()
 
 			select {

--- a/mesos/scheduler_test.go
+++ b/mesos/scheduler_test.go
@@ -171,8 +171,8 @@ func TestScheduler(t *testing.T) {
 
 				Convey("The task should contain the status history", func() {
 					So(task.Status, ShouldHaveLength, 2)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
-					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_STAGING)
+					So(task.Status[0].Status, ShouldEqual, eremetic.TaskQueued)
+					So(task.Status[1].Status, ShouldEqual, eremetic.TaskStaging)
 				})
 				Convey("The offer should not be declined", func() {
 					So(driver.AssertNotCalled(t, "DeclineOffer"), ShouldBeTrue)
@@ -230,7 +230,7 @@ func TestScheduler(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(len(task.Status), ShouldEqual, 1)
-				So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
+				So(task.Status[0].Status, ShouldEqual, eremetic.TaskRunning)
 
 				s.StatusUpdate(nil, &mesosproto.TaskStatus{
 					TaskId: &mesosproto.TaskID{
@@ -244,8 +244,8 @@ func TestScheduler(t *testing.T) {
 
 				Convey("The task status history should contain the failed status", func() {
 					So(len(task.Status), ShouldEqual, 2)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_RUNNING)
-					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
+					So(task.Status[0].Status, ShouldEqual, eremetic.TaskRunning)
+					So(task.Status[1].Status, ShouldEqual, eremetic.TaskFailed)
 				})
 			})
 
@@ -264,8 +264,8 @@ func TestScheduler(t *testing.T) {
 
 				Convey("The task should have a queued status", func() {
 					So(len(task.Status), ShouldEqual, 2)
-					So(task.Status[0].Status, ShouldEqual, eremetic.TaskState_TASK_FAILED)
-					So(task.Status[1].Status, ShouldEqual, eremetic.TaskState_TASK_QUEUED)
+					So(task.Status[0].Status, ShouldEqual, eremetic.TaskFailed)
+					So(task.Status[1].Status, ShouldEqual, eremetic.TaskQueued)
 				})
 
 				Convey("The task should be published on channel", func() {

--- a/mesos/task.go
+++ b/mesos/task.go
@@ -12,8 +12,8 @@ import (
 )
 
 func createTaskInfo(task eremetic.Task, offer *mesosproto.Offer) (eremetic.Task, *mesosproto.TaskInfo) {
-	task.FrameworkId = *offer.FrameworkId.Value
-	task.SlaveId = *offer.SlaveId.Value
+	task.FrameworkID = *offer.FrameworkId.Value
+	task.SlaveID = *offer.SlaveId.Value
 	task.Hostname = *offer.Hostname
 	task.AgentIP = offer.GetUrl().GetAddress().GetIp()
 	task.AgentPort = offer.GetUrl().GetAddress().GetPort()

--- a/mesos/task_test.go
+++ b/mesos/task_test.go
@@ -15,7 +15,7 @@ func TestTask(t *testing.T) {
 
 	status := []eremetic.Status{
 		eremetic.Status{
-			Status: eremetic.TaskState_TASK_RUNNING,
+			Status: eremetic.TaskRunning,
 			Time:   time.Now().Unix(),
 		},
 	}
@@ -60,7 +60,7 @@ func TestTask(t *testing.T) {
 			So(taskInfo.GetResources()[1].GetScalar().GetValue(), ShouldEqual, eremeticTask.TaskMem)
 			So(taskInfo.Container.GetType().String(), ShouldEqual, "DOCKER")
 			So(taskInfo.Container.Docker.GetImage(), ShouldEqual, "busybox")
-			So(net.SlaveId, ShouldEqual, "slave-id")
+			So(net.SlaveID, ShouldEqual, "slave-id")
 			So(taskInfo.Container.Docker.GetForcePullImage(), ShouldBeFalse)
 		})
 
@@ -114,9 +114,9 @@ func TestTask(t *testing.T) {
 			So(taskInfo.Container.Docker.GetPortMappings()[0].GetContainerPort(), ShouldEqual, ports[0].ContainerPort)
 			So(taskInfo.GetResources()[2].GetName(), ShouldEqual, "ports")
 
-			expected_range := mesosutil.NewValueRange(31000, 31001)
-			So(taskInfo.GetResources()[2].GetRanges().GetRange()[0].GetBegin(), ShouldEqual, expected_range.GetBegin())
-			So(taskInfo.GetResources()[2].GetRanges().GetRange()[0].GetEnd(), ShouldEqual, expected_range.GetEnd())
+			expectedRange := mesosutil.NewValueRange(31000, 31001)
+			So(taskInfo.GetResources()[2].GetRanges().GetRange()[0].GetBegin(), ShouldEqual, expectedRange.GetBegin())
+			So(taskInfo.GetResources()[2].GetRanges().GetRange()[0].GetEnd(), ShouldEqual, expectedRange.GetEnd())
 
 			vars := taskInfo.GetCommand().GetEnvironment().GetVariables()
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -6,16 +6,19 @@ import (
 	"github.com/klarna/eremetic"
 )
 
+// Scheduler mocks the eremetic scheduler.
 type Scheduler struct {
 	ScheduleTaskFn      func(req eremetic.Request) (string, error)
 	ScheduleTaskInvoked bool
 }
 
+// ScheduleTask invokes the ScheduleTaskFn function.
 func (s *Scheduler) ScheduleTask(req eremetic.Request) (string, error) {
 	s.ScheduleTaskInvoked = true
 	return s.ScheduleTaskFn(req)
 }
 
+// TaskDB mocks the eremetic task database.
 type TaskDB struct {
 	CleanFn                func() error
 	CloseFn                func()
@@ -25,34 +28,42 @@ type TaskDB struct {
 	ListNonTerminalTasksFn func() ([]*eremetic.Task, error)
 }
 
+// Clean invokes the CleanFn function.
 func (db *TaskDB) Clean() error {
 	return db.CleanFn()
 }
 
+// Close invokes the CloseFn function.
 func (db *TaskDB) Close() {
 	db.CloseFn()
 }
 
+// PutTask invokes the PutTaskFn function.
 func (db *TaskDB) PutTask(task *eremetic.Task) error {
 	return db.PutTaskFn(task)
 }
 
+// ReadTask invokes the ReadTaskFn function.
 func (db *TaskDB) ReadTask(id string) (eremetic.Task, error) {
 	return db.ReadTaskFn(id)
 }
 
+// ReadUnmaskedTask invokes the ReadUnmaskedTaskFn function.
 func (db *TaskDB) ReadUnmaskedTask(id string) (eremetic.Task, error) {
 	return db.ReadUnmaskedTaskFn(id)
 }
 
+// ListNonTerminalTasks invokes the ListNonTerminalTasksFn function.
 func (db *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 	return db.ListNonTerminalTasksFn()
 }
 
+// ErrScheduler mocks the eremetic scheduler.
 type ErrScheduler struct {
 	NextError *error
 }
 
+// ScheduleTask records any scheduling errors.
 func (s *ErrScheduler) ScheduleTask(request eremetic.Request) (string, error) {
 	if err := s.NextError; err != nil {
 		s.NextError = nil
@@ -63,8 +74,10 @@ func (s *ErrScheduler) ScheduleTask(request eremetic.Request) (string, error) {
 
 }
 
+// ErrorReader simulates a failure to read stream.
 type ErrorReader struct{}
 
+// Read always returns an error.
 func (r *ErrorReader) Read(p []byte) (int, error) {
 	return 0, errors.New("oh no")
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -6,6 +6,7 @@ import "errors"
 // to handle this as they see fit.
 var ErrQueueFull = errors.New("task queue is full")
 
+// Scheduler defines an interface for scheduling tasks.
 type Scheduler interface {
 	ScheduleTask(request Request) (string, error)
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -20,16 +20,18 @@ import (
 	"github.com/klarna/eremetic/version"
 )
 
-type ErrorDocument struct {
+type errorDocument struct {
 	Error   string `json:"error"`
 	Message string `json:"message"`
 }
 
+// Handler holds the server context.
 type Handler struct {
 	scheduler eremetic.Scheduler
 	database  eremetic.TaskDB
 }
 
+// NewHandler returns a new instance of Handler.
 func NewHandler(scheduler eremetic.Scheduler, database eremetic.TaskDB) Handler {
 	return Handler{
 		scheduler: scheduler,
@@ -61,7 +63,7 @@ func (h Handler) AddTask() http.HandlerFunc {
 			if err == eremetic.ErrQueueFull {
 				httpStatus = 503
 			}
-			errorMessage := ErrorDocument{
+			errorMessage := errorDocument{
 				err.Error(),
 				"Unable to schedule task",
 			}

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -28,7 +28,7 @@ func TestHandling(t *testing.T) {
 	scheduler := &mock.ErrScheduler{}
 	status := []eremetic.Status{
 		eremetic.Status{
-			Status: eremetic.TaskState_TASK_RUNNING,
+			Status: eremetic.TaskRunning,
 			Time:   time.Now().Unix(),
 		},
 	}

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -38,7 +38,7 @@ func getFile(file string, task eremetic.Task) (int, io.ReadCloser) {
 	response, err := http.Get(url)
 
 	if err != nil {
-		logrus.WithError(err).Errorf("Unable to fetch %s from agent %s.", file, task.SlaveId)
+		logrus.WithError(err).Errorf("Unable to fetch %s from agent %s.", file, task.SlaveID)
 		return http.StatusInternalServerError, ioutil.NopCloser(strings.NewReader("Unable to fetch upstream file."))
 	}
 
@@ -50,7 +50,7 @@ func handleError(err error, w http.ResponseWriter, message string) {
 		return
 	}
 
-	errorMessage := ErrorDocument{
+	errorMessage := errorDocument{
 		err.Error(),
 		message,
 	}
@@ -78,11 +78,11 @@ func renderHTML(w http.ResponseWriter, r *http.Request, task eremetic.Task, task
 	if reflect.DeepEqual(task, (eremetic.Task{})) {
 		notFound(w, r)
 		return
-	} else {
-		templateFile = "task.html"
-		data = makeMap(task)
-		data["Version"] = version.Version
 	}
+
+	templateFile = "task.html"
+	data = makeMap(task)
+	data["Version"] = version.Version
 
 	source, _ := assets.Asset(fmt.Sprintf("templates/%s", templateFile))
 	tpl, err := template.New(templateFile).Funcs(funcMap).Parse(string(source))
@@ -127,10 +127,10 @@ func makeMap(task eremetic.Task) map[string]interface{} {
 	data["Command"] = task.Command
 	// TODO: Support more than docker?
 	data["ContainerImage"] = task.Image
-	data["FrameworkID"] = task.FrameworkId
+	data["FrameworkID"] = task.FrameworkID
 	data["Hostname"] = task.Hostname
 	data["Name"] = task.Name
-	data["SlaveID"] = task.SlaveId
+	data["SlaveID"] = task.SlaveID
 	data["SlaveConstraints"] = task.SlaveConstraints
 	data["Status"] = task.Status
 	data["CPU"] = fmt.Sprintf("%.2f", task.TaskCPUs)

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -19,7 +19,7 @@ func TestHandlingHelpers(t *testing.T) {
 
 	status := []eremetic.Status{
 		eremetic.Status{
-			Status: eremetic.TaskState_TASK_RUNNING,
+			Status: eremetic.TaskRunning,
 			Time:   time.Now().Unix(),
 		},
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -159,7 +159,7 @@ func TestTask(t *testing.T) {
 			So(task.Image, ShouldEqual, "busybox")
 			So(task.Volumes, ShouldBeEmpty)
 			So(task.Status, ShouldHaveLength, 1)
-			So(task.Status[0].Status, ShouldEqual, TaskState_TASK_QUEUED)
+			So(task.Status[0].Status, ShouldEqual, TaskQueued)
 		})
 
 		Convey("Given a volume and environment", func() {
@@ -284,16 +284,16 @@ func TestTask(t *testing.T) {
 	})
 	Convey("states", t, func() {
 		terminalStates := []TaskState{
-			TaskState_TASK_FINISHED,
-			TaskState_TASK_FAILED,
-			TaskState_TASK_KILLED,
-			TaskState_TASK_LOST,
+			TaskFinished,
+			TaskFailed,
+			TaskKilled,
+			TaskLost,
 		}
 
 		nonTerminalStates := []TaskState{
-			TaskState_TASK_RUNNING,
-			TaskState_TASK_STAGING,
-			TaskState_TASK_STARTING,
+			TaskRunning,
+			TaskStaging,
+			TaskStarting,
 		}
 
 		Convey("IsTerminal", func() {

--- a/zk/zookeeper.go
+++ b/zk/zookeeper.go
@@ -30,6 +30,7 @@ type connector interface {
 	Connect(path string) (connection, error)
 }
 
+// TaskDB is a Zookeeper implementation of the task database.
 type TaskDB struct {
 	conn connection
 	path string
@@ -54,6 +55,7 @@ func parsePath(zkpath string) (string, string, error) {
 	return u.Host, path, nil
 }
 
+// NewTaskDB returns a new instance of a Zookeeper TaskDB.
 func NewTaskDB(zk string) (*TaskDB, error) {
 	return newCustomTaskDB(defaultConnector{}, zk)
 }
@@ -95,15 +97,18 @@ func newCustomTaskDB(c connector, path string) (*TaskDB, error) {
 	}, nil
 }
 
+// Close closes the connection to the database.
 func (z *TaskDB) Close() {
 	z.conn.Close()
 }
 
+// Clean removes all tasks from the database.
 func (z *TaskDB) Clean() error {
 	path := fmt.Sprintf("%s/", z.path)
 	return z.conn.Delete(path, -1)
 }
 
+// PutTask adds a new task to the database.
 func (z *TaskDB) PutTask(task *eremetic.Task) error {
 	path := fmt.Sprintf("%s/%s", z.path, task.ID)
 
@@ -130,6 +135,7 @@ func (z *TaskDB) PutTask(task *eremetic.Task) error {
 	return err
 }
 
+// ReadTask returns a task with a given id, or an error if not found.
 func (z *TaskDB) ReadTask(id string) (eremetic.Task, error) {
 	task, err := z.ReadUnmaskedTask(id)
 
@@ -138,6 +144,7 @@ func (z *TaskDB) ReadTask(id string) (eremetic.Task, error) {
 	return task, err
 }
 
+// ReadUnmaskedTask returns a task with all its environment variables unmasked.
 func (z *TaskDB) ReadUnmaskedTask(id string) (eremetic.Task, error) {
 	var task eremetic.Task
 	path := fmt.Sprintf("%s/%s", z.path, id)
@@ -149,6 +156,7 @@ func (z *TaskDB) ReadUnmaskedTask(id string) (eremetic.Task, error) {
 
 }
 
+// ListNonTerminalTasks returns all non-terminal tasks.
 func (z *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 	tasks := []*eremetic.Task{}
 	paths, _, _ := z.conn.Children(z.path)

--- a/zk/zookeeper_test.go
+++ b/zk/zookeeper_test.go
@@ -39,7 +39,7 @@ func TestZKDatabase(t *testing.T) {
 
 	status := []eremetic.Status{
 		eremetic.Status{
-			Status: eremetic.TaskState_TASK_RUNNING,
+			Status: eremetic.TaskRunning,
 			Time:   time.Now().Unix(),
 		},
 	}


### PR DESCRIPTION
This PR fixes the issues from running `golint` on eremetic. Unnecessarily exported symbols have been unexported and basic documentation has been added for the exported APIs.

Added basic linting and vetting targets to the Makefile.