### PR TITLE
Implemented delete task and added test for zk and bolt

### DIFF
--- a/boltdb/boltdb.go
+++ b/boltdb/boltdb.go
@@ -131,6 +131,16 @@ func (db *TaskDB) ReadUnmaskedTask(id string) (eremetic.Task, error) {
 	return task, err
 }
 
+func (db *TaskDB) DeleteTask(id string) error {
+	return db.conn.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("tasks"))
+		if err != nil {
+			return err
+		}
+		return b.Delete([]byte(id))
+	})
+}
+
 // ListNonTerminalTasks returns a list of tasks that are not yet finished in one
 // way or another.
 func (db *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {

--- a/boltdb/boltdb_test.go
+++ b/boltdb/boltdb_test.go
@@ -202,6 +202,27 @@ func TestBoltDatabase(t *testing.T) {
 		So(task.ID, ShouldEqual, "2345")
 	})
 
+	Convey("DeleteTask", t, func() {
+		Convey("Success", func() {
+			setup()
+			defer teardown()
+			defer db.Close()
+			db.Clean()
+
+			var maskedEnv = make(map[string]string)
+			maskedEnv["foo"] = "bar"
+
+			task1 := eremetic.Task{ID: "1234"}
+			db.PutTask(&task1)
+			t1, err := db.ReadUnmaskedTask(task1.ID)
+			So(t1, ShouldResemble, task1)
+			So(err, ShouldBeNil)
+
+			err = db.DeleteTask(task1.ID)
+			So(err, ShouldBeNil)
+		})
+	})
+
 	Convey("List non-terminal tasks no running task", t, func() {
 		setup()
 		defer teardown()

--- a/database.go
+++ b/database.go
@@ -28,6 +28,7 @@ type TaskDB interface {
 	Close()
 	PutTask(task *Task) error
 	ReadTask(id string) (Task, error)
+	DeleteTask(id string) error
 	ReadUnmaskedTask(id string) (Task, error)
 	ListNonTerminalTasks() ([]*Task, error)
 }
@@ -74,6 +75,18 @@ func (db *DefaultTaskDB) ReadTask(id string) (Task, error) {
 	}
 	return Task{}, errors.New("unknown task")
 }
+
+// Deletes the task with a given id, or an error if not found.
+func (db *DefaultTaskDB) DeleteTask(id string) error {
+	db.mtx.RLock()
+	defer db.mtx.RUnlock()
+	if _, ok := db.tasks[id]; ok {
+		delete(db.tasks, id)
+		return nil
+	}
+	return errors.New("unknown task")
+}
+
 
 // ReadUnmaskedTask returns a task with all its environment variables unmasked.
 func (db *DefaultTaskDB) ReadUnmaskedTask(id string) (Task, error) {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -32,6 +32,7 @@ type TaskDB struct {
 	PutTaskFn              func(*eremetic.Task) error
 	ReadTaskFn             func(string) (eremetic.Task, error)
 	ReadUnmaskedTaskFn     func(string) (eremetic.Task, error)
+	DeleteTaskFn           func(string) error
 	ListNonTerminalTasksFn func() ([]*eremetic.Task, error)
 }
 
@@ -58,6 +59,11 @@ func (db *TaskDB) ReadTask(id string) (eremetic.Task, error) {
 // ReadUnmaskedTask invokes the ReadUnmaskedTaskFn function.
 func (db *TaskDB) ReadUnmaskedTask(id string) (eremetic.Task, error) {
 	return db.ReadUnmaskedTaskFn(id)
+}
+
+// ReadUnmaskedTask invokes the ReadUnmaskedTaskFn function.
+func (db *TaskDB) DeleteTask(id string) error {
+	return db.DeleteTaskFn(id)
 }
 
 // ListNonTerminalTasks invokes the ListNonTerminalTasksFn function.

--- a/server/handler.go
+++ b/server/handler.go
@@ -190,3 +190,20 @@ func (h Handler) KillTask(conf *config.Config) http.HandlerFunc {
 		writeJSON(respStatus, body, w)
 	}
 }
+
+func (h Handler) DeleteTask(conf *config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["taskId"]
+		logrus.WithField("task_id", id).Debug("Deleting task")
+		err :=  h.database.DeleteTask(id)
+		respStatus := http.StatusAccepted
+		var body string
+		if err != nil {
+			respStatus = http.StatusInternalServerError
+			body = err.Error()
+		}
+		writeJSON(respStatus, body, w)
+	}
+}
+

--- a/server/handler.go
+++ b/server/handler.go
@@ -196,7 +196,7 @@ func (h Handler) DeleteTask(conf *config.Config) http.HandlerFunc {
 		vars := mux.Vars(r)
 		id := vars["taskId"]
 		logrus.WithField("task_id", id).Debug("Deleting task")
-		err :=  h.database.DeleteTask(id)
+		err := h.database.DeleteTask(id)
 		respStatus := http.StatusAccepted
 		var body string
 		if err != nil {
@@ -206,4 +206,3 @@ func (h Handler) DeleteTask(conf *config.Config) http.HandlerFunc {
 		writeJSON(respStatus, body, w)
 	}
 }
-

--- a/server/handler.go
+++ b/server/handler.go
@@ -196,9 +196,22 @@ func (h Handler) DeleteTask(conf *config.Config) http.HandlerFunc {
 		vars := mux.Vars(r)
 		id := vars["taskId"]
 		logrus.WithField("task_id", id).Debug("Deleting task")
-		err := h.database.DeleteTask(id)
 		respStatus := http.StatusAccepted
 		var body string
+		task, err := h.database.ReadTask(id)
+		if (err != nil) {
+			respStatus = http.StatusNotFound
+			writeJSON(respStatus, err.Error(), w)
+			return
+		}
+		if (task.IsRunning()) {
+			respStatus = http.StatusConflict
+			errMsg := fmt.Sprintf("Cannot delete the task [%s]. As it is still running.", id)
+			logrus.WithField("task_id", id).Debug(errMsg)
+			writeJSON(respStatus, errMsg, w)
+			return
+		}
+		err = h.database.DeleteTask(id)
 		if err != nil {
 			respStatus = http.StatusInternalServerError
 			body = err.Error()

--- a/server/routes.go
+++ b/server/routes.go
@@ -28,14 +28,14 @@ func NewRouter(scheduler eremetic.Scheduler, conf *config.Config, db eremetic.Ta
 
 	for _, route := range routes(h, conf) {
 		router.
-		Methods(route.Method).
+			Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name).
 			Handler(prometheus.InstrumentHandler(route.Name, route.Handler))
 	}
 
 	router.
-	PathPrefix("/static/").
+		PathPrefix("/static/").
 		Handler(h.StaticAssets())
 
 	router.NotFoundHandler = http.HandlerFunc(h.NotFound())

--- a/server/routes.go
+++ b/server/routes.go
@@ -28,14 +28,14 @@ func NewRouter(scheduler eremetic.Scheduler, conf *config.Config, db eremetic.Ta
 
 	for _, route := range routes(h, conf) {
 		router.
-			Methods(route.Method).
+		Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name).
 			Handler(prometheus.InstrumentHandler(route.Name, route.Handler))
 	}
 
 	router.
-		PathPrefix("/static/").
+	PathPrefix("/static/").
 		Handler(h.StaticAssets())
 
 	router.NotFoundHandler = http.HandlerFunc(h.NotFound())
@@ -74,6 +74,12 @@ func routes(h Handler, conf *config.Config) Routes {
 			Method:  "POST",
 			Pattern: "/task/{taskId}/kill",
 			Handler: h.KillTask(conf),
+		},
+		Route{
+			Name:    "Delete",
+			Method:  "DELETE",
+			Pattern: "/task/{taskId}",
+			Handler: h.DeleteTask(conf),
 		},
 		Route{
 			Name:    "ListRunningTasks",

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -24,7 +24,7 @@ func TestRoutes(t *testing.T) {
 	})
 
 	Convey("Expected number of routes", t, func() {
-		ExpectedNumberOfRoutes := 9 // Magic numbers FTW
+		ExpectedNumberOfRoutes := 10 // Magic numbers FTW
 
 		So(len(routes), ShouldEqual, ExpectedNumberOfRoutes)
 	})

--- a/zk/zookeeper.go
+++ b/zk/zookeeper.go
@@ -167,7 +167,6 @@ func (z *TaskDB) DeleteTask(id string) error {
 	return err
 }
 
-
 // ListNonTerminalTasks returns all non-terminal tasks.
 func (z *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 	tasks := []*eremetic.Task{}

--- a/zk/zookeeper.go
+++ b/zk/zookeeper.go
@@ -156,6 +156,18 @@ func (z *TaskDB) ReadUnmaskedTask(id string) (eremetic.Task, error) {
 
 }
 
+func (z *TaskDB) DeleteTask(id string) error {
+	path := fmt.Sprintf("%s/%s", z.path, id)
+	_, stat, err := z.conn.Exists(path)
+	if err != nil {
+		logrus.WithError(err).Error("Unable to check existance of database.")
+		return err
+	}
+	err = z.conn.Delete(path, stat.Version)
+	return err
+}
+
+
 // ListNonTerminalTasks returns all non-terminal tasks.
 func (z *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 	tasks := []*eremetic.Task{}

--- a/zk/zookeeper_test.go
+++ b/zk/zookeeper_test.go
@@ -208,7 +208,7 @@ func TestZKDatabase(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(object.AssertCalled(t, "Exists", "/testdb/1234"), ShouldBeTrue)
 			So(object.AssertNumberOfCalls(t, "Delete", 1), ShouldBeTrue)
-			So(object.AssertCalled(t, "Delete","/testdb/1234", int32(0)), ShouldBeTrue)
+			So(object.AssertCalled(t, "Delete", "/testdb/1234", int32(0)), ShouldBeTrue)
 		})
 
 		Convey("Error", func() {

--- a/zk/zookeeper_test.go
+++ b/zk/zookeeper_test.go
@@ -195,6 +195,36 @@ func TestZKDatabase(t *testing.T) {
 		})
 	})
 
+	Convey("DeleteTask", t, func() {
+		Convey("Success", func() {
+			setup()
+			defer teardown()
+
+			object.On("Exists", mock.AnythingOfType("string")).Return(true, &zk.Stat{}, nil)
+			object.On("Delete", mock.AnythingOfType("string"), mock.AnythingOfType("int32")).Return(nil)
+
+			err := db.DeleteTask(task.ID)
+
+			So(err, ShouldBeNil)
+			So(object.AssertCalled(t, "Exists", "/testdb/1234"), ShouldBeTrue)
+			So(object.AssertNumberOfCalls(t, "Delete", 1), ShouldBeTrue)
+			So(object.AssertCalled(t, "Delete","/testdb/1234", int32(0)), ShouldBeTrue)
+		})
+
+		Convey("Error", func() {
+			setup()
+			defer teardown()
+
+			object.On("Exists", mock.AnythingOfType("string")).Return(false, &zk.Stat{}, errors.New("Bad Connection"))
+
+			err := db.DeleteTask(task.ID)
+
+			So(err, ShouldNotBeNil)
+			So(object.AssertCalled(t, "Exists", "/testdb/1234"), ShouldBeTrue)
+			So(object.AssertNumberOfCalls(t, "Delete", 0), ShouldBeTrue)
+		})
+	})
+
 	Convey("ReadUnmaskedTask", t, func() {
 		Convey("Success", func() {
 			setup()


### PR DESCRIPTION
This PR adds a simple delete through API REST.

It's useful for cases where the framework has tasks in the queue, but Mesos cannot provide appropriate resources to the framework. 