### PR TITLE
Add support for network host mode and pass dns to the docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ JSON format:
       "host_path": "/var/run/docker.sock"
     }
   ],
+  //String, network mode to pass to the container.
+  "network" : "BRIDGE",
+  //String, DNS address to be used by the container.
+   "dns" : "172.0.0.2",
   // Array of Objects, ports to forward to the container.
   // Assigned host ports are available as environment variables (e.g. PORT0, PORT1 and so on with PORT being an alias for PORT0).
   "ports": [

--- a/cmd/hermit/main.go
+++ b/cmd/hermit/main.go
@@ -87,10 +87,12 @@ func newFlagSet(name string, synopsis string, description string) *flag.FlagSet 
 }
 
 type runCommand struct {
-	CPU    float64
-	Memory float64
-	Image  string
-	Port   uint
+	CPU     float64
+	Memory  float64
+	Image   string
+	Port    uint
+	Network string
+	DNS     string
 	EnvVars EnvironmentVariables
 
 	flags  *flag.FlagSet
@@ -126,6 +128,8 @@ func (cmd *runCommand) Parse(args []string) {
 	cmd.flags.Float64Var(&cmd.Memory, "mem", 128, "Memory in MB to give to the task")
 	cmd.flags.StringVar(&cmd.Image, "image", "busybox", "Image to use")
 	cmd.flags.UintVar(&cmd.Port, "port", 0, "Port for task to listen on")
+	cmd.flags.StringVar(&cmd.Network, "network", "BRIDGE", "Network mode for the task. default value is BRIDGE")
+	cmd.flags.StringVar(&cmd.DNS, "dns", "", "Dns to be used by the task")
 	cmd.flags.Var(&cmd.EnvVars, "e", "Envrionment variables. e.g. -e MYVAR1=myvalue1 -e MYVAR2=myvalue2")
 	cmd.flags.Parse(args)
 }
@@ -151,6 +155,8 @@ func (cmd *runCommand) Run() {
 			},
 		},
 		Environment: cmd.EnvVars,
+		Network:     cmd.Network,
+		DNS:         cmd.DNS,
 	}
 
 	if err := cmd.client.AddTask(r); err != nil {

--- a/mesos/task.go
+++ b/mesos/task.go
@@ -65,15 +65,10 @@ func buildDockerCliParameters(task eremetic.Task) []*mesosproto.Parameter {
 }
 
 func buildNetwork(task eremetic.Task) *mesosproto.ContainerInfo_DockerInfo_Network {
-	var network mesosproto.ContainerInfo_DockerInfo_Network
 	if task.Network == "" {
-		network = mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[mesosproto.ContainerInfo_DockerInfo_BRIDGE.String()])
-	} else {
-		network = mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[task.Network])
+		return mesosproto.ContainerInfo_DockerInfo_BRIDGE.Enum()
 	}
-	p := new(mesosproto.ContainerInfo_DockerInfo_Network)
-	*p = network
-	return p
+	return mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[task.Network]).Enum()
 }
 
 func buildEnvironment(task eremetic.Task, portMappings []*mesosproto.ContainerInfo_DockerInfo_PortMapping) *mesosproto.Environment {

--- a/mesos/task.go
+++ b/mesos/task.go
@@ -18,7 +18,9 @@ func createTaskInfo(task eremetic.Task, offer *mesosproto.Offer) (eremetic.Task,
 	task.AgentIP = offer.GetUrl().GetAddress().GetIp()
 	task.AgentPort = offer.GetUrl().GetAddress().GetPort()
 
-	portMapping, portResources := buildPorts(task, offer)
+	network := buildNetwork(task)
+	dockerCliParameters := buildDockerCliParameters(task)
+	portMapping, portResources := buildPorts(task, network, offer)
 	env := buildEnvironment(task, portMapping)
 
 	taskInfo := &mesosproto.TaskInfo{
@@ -31,8 +33,9 @@ func createTaskInfo(task eremetic.Task, offer *mesosproto.Offer) (eremetic.Task,
 			Docker: &mesosproto.ContainerInfo_DockerInfo{
 				Image:          proto.String(task.Image),
 				ForcePullImage: proto.Bool(task.ForcePullImage),
+				Network:        network,
 				PortMappings:   portMapping,
-				Network:        mesosproto.ContainerInfo_DockerInfo_BRIDGE.Enum(),
+				Parameters:     dockerCliParameters,
 			},
 			Volumes: buildVolumes(task),
 		},
@@ -43,6 +46,34 @@ func createTaskInfo(task eremetic.Task, offer *mesosproto.Offer) (eremetic.Task,
 		},
 	}
 	return task, taskInfo
+}
+
+func buildDockerCliParameters(task eremetic.Task) []*mesosproto.Parameter {
+	//To be able to move away from docker CLI in future, parameters aren't fully exposed to the API
+	params := make(map[string]string)
+	if task.DNS != "" {
+		params["dns"] = task.DNS
+	}
+	var parameters []*mesosproto.Parameter
+	for k, v := range params {
+		parameters = append(parameters, &mesosproto.Parameter{
+			Key: proto.String(k),
+			Value: proto.String(v),
+		})
+	}
+	return parameters
+}
+
+func buildNetwork(task eremetic.Task) *mesosproto.ContainerInfo_DockerInfo_Network {
+	var network mesosproto.ContainerInfo_DockerInfo_Network
+	if (task.Network == "") {
+		network = mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[mesosproto.ContainerInfo_DockerInfo_BRIDGE.String()])
+	} else {
+		network = mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[task.Network])
+	}
+	p := new(mesosproto.ContainerInfo_DockerInfo_Network)
+	*p = network
+	return p
 }
 
 func buildEnvironment(task eremetic.Task, portMappings []*mesosproto.ContainerInfo_DockerInfo_PortMapping) *mesosproto.Environment {
@@ -95,11 +126,11 @@ func buildVolumes(task eremetic.Task) []*mesosproto.Volume {
 	return volumes
 }
 
-func buildPorts(task eremetic.Task, offer *mesosproto.Offer) ([]*mesosproto.ContainerInfo_DockerInfo_PortMapping, []*mesosproto.Value_Range) {
+func buildPorts(task eremetic.Task, network  *mesosproto.ContainerInfo_DockerInfo_Network, offer *mesosproto.Offer) ([]*mesosproto.ContainerInfo_DockerInfo_PortMapping, []*mesosproto.Value_Range) {
 	var resources []*mesosproto.Value_Range
 	var mappings []*mesosproto.ContainerInfo_DockerInfo_PortMapping
 
-	if len(task.Ports) == 0 {
+	if len(task.Ports) == 0 || *network == mesosproto.ContainerInfo_DockerInfo_HOST {
 		return mappings, resources
 	}
 

--- a/mesos/task.go
+++ b/mesos/task.go
@@ -57,7 +57,7 @@ func buildDockerCliParameters(task eremetic.Task) []*mesosproto.Parameter {
 	var parameters []*mesosproto.Parameter
 	for k, v := range params {
 		parameters = append(parameters, &mesosproto.Parameter{
-			Key: proto.String(k),
+			Key:   proto.String(k),
 			Value: proto.String(v),
 		})
 	}
@@ -66,7 +66,7 @@ func buildDockerCliParameters(task eremetic.Task) []*mesosproto.Parameter {
 
 func buildNetwork(task eremetic.Task) *mesosproto.ContainerInfo_DockerInfo_Network {
 	var network mesosproto.ContainerInfo_DockerInfo_Network
-	if (task.Network == "") {
+	if task.Network == "" {
 		network = mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[mesosproto.ContainerInfo_DockerInfo_BRIDGE.String()])
 	} else {
 		network = mesosproto.ContainerInfo_DockerInfo_Network(mesosproto.ContainerInfo_DockerInfo_Network_value[task.Network])
@@ -126,7 +126,7 @@ func buildVolumes(task eremetic.Task) []*mesosproto.Volume {
 	return volumes
 }
 
-func buildPorts(task eremetic.Task, network  *mesosproto.ContainerInfo_DockerInfo_Network, offer *mesosproto.Offer) ([]*mesosproto.ContainerInfo_DockerInfo_PortMapping, []*mesosproto.Value_Range) {
+func buildPorts(task eremetic.Task, network *mesosproto.ContainerInfo_DockerInfo_Network, offer *mesosproto.Offer) ([]*mesosproto.ContainerInfo_DockerInfo_PortMapping, []*mesosproto.Value_Range) {
 	var resources []*mesosproto.Value_Range
 	var mappings []*mesosproto.ContainerInfo_DockerInfo_PortMapping
 

--- a/mesos/task_test.go
+++ b/mesos/task_test.go
@@ -96,6 +96,22 @@ func TestTask(t *testing.T) {
 			So(taskInfo.Command.Environment.Variables[1].GetValue(), ShouldEqual, eremeticTask.ID)
 		})
 
+		Convey("Given no network", func() {
+			_, taskInfo := createTaskInfo(eremeticTask, &offer)
+
+			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
+			So(taskInfo.Container.Docker.Network.String(), ShouldEqual, "BRIDGE")
+		})
+
+		Convey("Given network", func() {
+			eremeticTask.Network = "HOST"
+			_, taskInfo := createTaskInfo(eremeticTask, &offer)
+
+			So(taskInfo.TaskId.GetValue(), ShouldEqual, eremeticTask.ID)
+			So(taskInfo.Container.Docker.Network.String(), ShouldEqual, "HOST")
+			So(taskInfo.Container.Docker.PortMappings, ShouldBeEmpty)
+		})
+
 		Convey("Given a port", func() {
 			var ports []eremetic.Port
 

--- a/misc/swagger.yaml
+++ b/misc/swagger.yaml
@@ -97,6 +97,12 @@ definitions:
       command:
         type: string
         description: Command to run in the docker container
+      network:
+        type: string
+        description: Network mode to pass to the container
+      dns:
+        type: string
+        description: DNS to be used by the container
       args:
         type: array 
         description: arguements to pass to the docker container entrypoint

--- a/task.go
+++ b/task.go
@@ -93,6 +93,8 @@ type Task struct {
 	Status            []Status          `json:"status"`
 	ID                string            `json:"id"`
 	Name              string            `json:"name"`
+	Network           string            `json:"network"`
+	DNS               string            `json:"dns"`
 	FrameworkID       string            `json:"framework_id"`
 	SlaveID           string            `json:"slave_id"`
 	SlaveConstraints  []SlaveConstraint `json:"slave_constraints"`
@@ -146,6 +148,8 @@ type Request struct {
 	Args              []string          `json:"args"`
 	Volumes           []Volume          `json:"volumes"`
 	Ports             []Port            `json:"ports"`
+	Network           string            `json:"network"`
+	DNS               string            `json:"dns"`
 	Environment       map[string]string `json:"env"`
 	MaskedEnvironment map[string]string `json:"masked_env"`
 	SlaveConstraints  []SlaveConstraint `json:"slave_constraints"`
@@ -171,6 +175,8 @@ func NewTask(request Request, name string) (Task, error) {
 		TaskCPUs:          request.TaskCPUs,
 		TaskMem:           request.TaskMem,
 		Name:              name,
+		Network:           request.Network,
+		DNS:               request.DNS,
 		Status:            status,
 		Command:           request.Command,
 		Args:              request.Args,

--- a/task_test.go
+++ b/task_test.go
@@ -194,6 +194,26 @@ func TestTask(t *testing.T) {
 			So(task.MaskedEnvironment["foo"], ShouldEqual, "bar")
 		})
 
+		Convey("Given a network type", func() {
+			network := "HOST"
+
+			request.Network = network
+			task, err := NewTask(request, "")
+
+			So(err, ShouldBeNil)
+			So(task.Network, ShouldEqual, "HOST")
+		})
+
+		Convey("Given a dns", func() {
+			dns := "172.17.0.1"
+
+			request.DNS = dns
+			task, err := NewTask(request, "")
+
+			So(err, ShouldBeNil)
+			So(task.DNS, ShouldEqual, "172.17.0.1")
+		})
+
 		Convey("Given URI (via uris) to download", func() {
 			request.URIs = []string{"http://foobar.local/kitten.jpg"}
 


### PR DESCRIPTION
-support for the network mode host
-pass the dns parameter to the docker

As we discussed earlier I have added the flag for the dns to avoid opening the parameters in the Eremetic API.
